### PR TITLE
Get data values for multiple org units

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -42,8 +42,7 @@ const App = () => (
           monthly: "monthYear",
           sixMonthly: "sixMonth"
         },
-        levels: ["Country", "Territory", "Land", "Facility"],
-        contractedOrgUnitGroupId: "GGghZsfu7qV"
+        levels: ["Country", "Territory", "Land", "Facility"]
       }
     }}
     dhis2={new Dhis2()}

--- a/example/src/invoices/Invoices.js
+++ b/example/src/invoices/Invoices.js
@@ -7,6 +7,8 @@ import DemoMapper from "./demo-chc/Mapper";
 import DemoInvoice from "./demo-chc/Invoice";
 import DemoMonthlyMapper from "./demo-chc-monthly/Mapper";
 import DemoMonthlyInvoice from "./demo-chc-monthly/Invoice";
+import DemoConsolidatedMapper from "./demo-chc-consolidated/Mapper";
+import DemoConsolidatedInvoice from "./demo-chc-consolidated/Invoice";
 
 import {
   indexBy,
@@ -17,6 +19,7 @@ import {
 const INVOICE_DEMO_CHT = "demo-chc";
 const INVOICE_DEMO_CHT_MONTHLY = "demo-chc-monthly";
 const INVOICE_DEMO_CHT_SEMIANNUALLY = "demo-chc-sixMonthly";
+const INVOICE_DEMO_CHT_CONSOLIDATED = "demo-chc-consolidated";
 
 const INVOICES = {
   [INVOICE_DEMO_CHT]: {
@@ -30,6 +33,10 @@ const INVOICES = {
   [INVOICE_DEMO_CHT_SEMIANNUALLY]: {
     component: DemoInvoice,
     mapper: DemoMapper
+  },
+  [INVOICE_DEMO_CHT_CONSOLIDATED]: {
+    component: DemoConsolidatedInvoice,
+    mapper: DemoConsolidatedMapper
   }
 };
 
@@ -42,6 +49,9 @@ class Invoices {
       INVOICE_DEMO_CHT_MONTHLY,
       INVOICE_DEMO_CHT_SEMIANNUALLY
     ];
+    if (orgUnit.level === 1) {
+      invoiceCodes.push(INVOICE_DEMO_CHT_CONSOLIDATED);
+    }
     return invoiceCodes;
   }
 

--- a/example/src/invoices/demo-chc-consolidated/Invoice.js
+++ b/example/src/invoices/demo-chc-consolidated/Invoice.js
@@ -15,7 +15,6 @@ class Invoice extends Component {
   render() {
     const classes = this.props.classes;
     const totals = this.props.invoice.totals;
-    const values = this.props.invoice.values;
     return (
       <div className={classes.invoiceFrame} id="invoiceFrame">
         <h1>Demo</h1>
@@ -47,19 +46,16 @@ class Invoice extends Component {
                     variant="text"
                     value={orgUnit.orgUnit.ancestors[0].name}
                     field="self"
-                    bold
                   />
                   <Cell
                     variant="text"
                     value={orgUnit.orgUnit.ancestors[1].name}
                     field="self"
-                    bold
                   />
                   <Cell
                     variant="text"
                     value={orgUnit.orgUnit.ancestors[2].name}
                     field="self"
-                    bold
                   />
                   <Cell
                     variant="text"
@@ -71,7 +67,7 @@ class Invoice extends Component {
                     variant="money"
                     value={orgUnit}
                     field="total"
-                    decimals={4}
+                    decimals={0}
                   />
                 </tr>
               );

--- a/example/src/invoices/demo-chc-consolidated/Invoice.js
+++ b/example/src/invoices/demo-chc-consolidated/Invoice.js
@@ -1,0 +1,86 @@
+import React, { Component } from "react";
+import { withStyles } from "@material-ui/core/styles";
+import { Cell } from "@blsq/blsq-report-components";
+const styles = {
+  invoiceFrame: {
+    backgroundColor: "#ffffff",
+    padding: "5px"
+  },
+  hLine: {
+    borderBottom: "1px solid black"
+  }
+};
+
+class Invoice extends Component {
+  render() {
+    const classes = this.props.classes;
+    const totals = this.props.invoice.totals;
+    const values = this.props.invoice.values;
+    return (
+      <div className={classes.invoiceFrame} id="invoiceFrame">
+        <h1>Demo</h1>
+        <p>{this.props.invoice.orgUnit.name}</p>
+
+        <table
+          style={{
+            borderCollapse: "collapse",
+            fontSize: "11px",
+            border: "0.5pt solid black"
+          }}
+        >
+          <thead>
+            <tr>
+              <Cell variant="text" value="Order" field="self" />
+              <Cell variant="text" value="National" field="self" />
+              <Cell variant="text" value="District" field="self" />
+              <Cell variant="text" value="Chiefdom" field="self" />
+              <Cell variant="text" value="Facility" field="self" />
+              <Cell variant="text" value="Value" field="self" />
+            </tr>
+          </thead>
+          <tbody>
+            {totals.map((orgUnit, index) => {
+              return (
+                <tr key={index}>
+                  <Cell variant="order" value={index} field="self" />
+                  <Cell
+                    variant="text"
+                    value={orgUnit.orgUnit.ancestors[0].name}
+                    field="self"
+                    bold
+                  />
+                  <Cell
+                    variant="text"
+                    value={orgUnit.orgUnit.ancestors[1].name}
+                    field="self"
+                    bold
+                  />
+                  <Cell
+                    variant="text"
+                    value={orgUnit.orgUnit.ancestors[2].name}
+                    field="self"
+                    bold
+                  />
+                  <Cell
+                    variant="text"
+                    value={orgUnit.orgUnit.name}
+                    field="self"
+                    bold
+                  />
+                  <Cell
+                    variant="money"
+                    value={orgUnit}
+                    field="total"
+                    decimals={4}
+                  />
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(Invoice);

--- a/example/src/invoices/demo-chc-consolidated/Mapper.js
+++ b/example/src/invoices/demo-chc-consolidated/Mapper.js
@@ -1,0 +1,25 @@
+class Mapper {
+  mapValues(request, values) {
+    let totals = [];
+    request.orgUnits.forEach(orgUnit => {
+      let total = values.amountByOrgUnit(
+        "HLPuaFB7Frw",
+        orgUnit.id,
+        request.quarterPeriod
+      );
+      totals.push({ orgUnit: orgUnit, total: total });
+    });
+    const invoice = {
+      orgUnit: request.mainOrgUnit,
+      orgUnits: request.orgUnits,
+      year: request.year,
+      quarter: request.quarter,
+      activities: [],
+      values: values.values,
+      totals: totals
+    };
+    return invoice;
+  }
+}
+
+export default Mapper;

--- a/example/src/invoices/demo-chc-consolidated/Mapper.js
+++ b/example/src/invoices/demo-chc-consolidated/Mapper.js
@@ -2,11 +2,13 @@ class Mapper {
   mapValues(request, values) {
     let totals = [];
     request.orgUnits.forEach(orgUnit => {
+      // reuse the data element from project descriptor
       let total = values.amountByOrgUnit(
         "HLPuaFB7Frw",
         orgUnit.id,
-        request.quarterPeriod
+        request.monthlyPeriods[2]
       );
+
       totals.push({ orgUnit: orgUnit, total: total });
     });
     const invoice = {

--- a/example/src/invoices/demo-chc/Mapper.js
+++ b/example/src/invoices/demo-chc/Mapper.js
@@ -1,17 +1,16 @@
 class Mapper {
   mapValues(request, values) {
     const invoice = {
-        orgUnit: request.orgUnit,
-        orgUnits: request.orgUnits,
-        year: request.year,
-        quarter: request.quarter,
-        activities: [],
-        total: {}
-      };
-      return invoice;
-
+      orgUnit: request.orgUnit,
+      orgUnits: request.orgUnits,
+      year: request.year,
+      quarter: request.quarter,
+      activities: [],
+      total: {},
+      values: values.values
+    };
+    return invoice;
   }
 }
 
-
-export default Mapper
+export default Mapper;

--- a/example/src/invoices/invoice-descriptors.json
+++ b/example/src/invoices/invoice-descriptors.json
@@ -25,5 +25,15 @@
     "frequency": "sixMonthly",
     "dataSets": [],
     "dataElementGroups": ["oDkJh5Ddh7d"]
+  },
+  {
+    "code": "demo-chc-consolidated",
+    "name": "demo-chc-consolidated",
+    "facilityLabel": "demo-consolidated",
+    "orientation": "landscape",
+    "frequency": "quarterly",
+    "dataSets": [],
+    "dataElementGroups": ["oDkJh5Ddh7d"],
+    "organisationUnitGroup": "oRVt7g429ZO"
   }
 ]

--- a/src/components/AppDrawer.js
+++ b/src/components/AppDrawer.js
@@ -200,7 +200,6 @@ class App extends React.Component {
     const frequency = this.state.period.includes("S")
       ? "sixMonthly"
       : "quarterly";
-    console.log(this.props);
     const params = {
       config: this.props.config,
       dhis2: this.props.dhis2,

--- a/src/components/browsedata/BrowseDataContainer.js
+++ b/src/components/browsedata/BrowseDataContainer.js
@@ -9,12 +9,6 @@ import Cell from "../shared/Cell";
 import Loader from "../shared/Loader";
 import DegNavigationBar from "./DegNavigationBar";
 
-Array.prototype.eachSlice = function(size, callback) {
-  for (var i = 0, l = this.length; i < l; i += size) {
-    callback.call(this, this.slice(i, i + size));
-  }
-};
-
 const styles = {
   table: {
     borderCollapse: "collapse",

--- a/src/support/Arrays.js
+++ b/src/support/Arrays.js
@@ -1,3 +1,9 @@
+Array.prototype.eachSlice = function(size, callback) {
+  for (var i = 0, l = this.length; i < l; i += size) {
+    callback.call(this, this.slice(i, i + size));
+  }
+};
+
 export function indexBy(array, f) {
   var groups = {};
   array.forEach(function(o) {

--- a/src/support/Arrays.test.js
+++ b/src/support/Arrays.test.js
@@ -1,0 +1,18 @@
+import Arrays from "./Arrays";
+
+function mapSlices(size, array) {
+  const results = [];
+  array.eachSlice(size, slice => {
+    results.push(slice);
+  });
+  return results;
+}
+
+it("Should Slice an array", () => {
+  expect(mapSlices(1, [1, 2, 3, 4])).toEqual([[1], [2], [3], [4]]);
+  expect(mapSlices(2, [1, 2, 3, 4])).toEqual([[1, 2], [3, 4]]);
+  expect(mapSlices(3, [1, 2, 3, 4])).toEqual([[1, 2, 3], [4]]);
+  expect(mapSlices(4, [1, 2, 3, 4])).toEqual([[1, 2, 3, 4]]);
+  expect(mapSlices(5, [1, 2, 3, 4])).toEqual([[1, 2, 3, 4]]);
+  expect(mapSlices(5, [])).toEqual([]);
+});

--- a/src/support/Dhis2.js
+++ b/src/support/Dhis2.js
@@ -322,9 +322,6 @@ class Dhis2 {
       orgUnits = request.orgUnits;
     }
 
-    const orgUnitsQuery = orgUnits
-      .map(orgUnit => "orgUnit=" + orgUnit.id)
-      .join("&");
     const degQuery = request.invoiceType.dataElementGroups
       .map(deg => "dataElementGroup=" + deg)
       .join("&");
@@ -337,15 +334,29 @@ class Dhis2 {
     const periodsQuery = periods.map(p => "&period=" + p).join("");
 
     const dataValuesUrl =
-      "dataValueSets?" +
-      orgUnitsQuery +
-      "&" +
-      degQuery +
-      "&" +
-      dsQuery +
-      periodsQuery;
+      "dataValueSets?" + degQuery + "&" + dsQuery + periodsQuery;
 
-    return getInstance().then(d2 => d2.Api.getApi().get(dataValuesUrl));
+    return getInstance()
+      .then(d2 => {
+        const queries = [];
+        orgUnits.eachSlice(200, orgUnitsSlice => {
+          const orgUnitsQuery = orgUnitsSlice
+            .map(orgUnit => "orgUnit=" + orgUnit.id)
+            .join("&");
+          queries.push(dataValuesUrl + "&" + orgUnitsQuery);
+        });
+
+        return Promise.all(queries.map(query => d2.Api.getApi().get(query)));
+      })
+      .then(results => {
+        let dataValues = [];
+        results.forEach(result => {
+          if (result.dataValues) {
+            dataValues = dataValues.concat(result.dataValues);
+          }
+        });
+        return { dataValues };
+      });
   }
 
   /**


### PR DESCRIPTION
 - allow the app to be able to get dataValues for multiple orgUnits by slicing the query

- add a consolidated example invoice and allow the level one orgUnit to be searched

- http://localhost:3000/index.html#/invoices/2018Q4/ImspTQPwCqd/demo-chc-consolidated

- 
![blsq report components](https://user-images.githubusercontent.com/19631540/51626657-b2d63580-1f48-11e9-9697-17b7bddcbd76.png)
