### PR TITLE
fixed (current) quarter guessing

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -24137,7 +24137,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "requires": {
         "inherits": "~2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14868,15 +14868,6 @@
         "rollup-pluginutils": "^2.3.3"
       }
     },
-    "rollup-plugin-json": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-json/-/rollup-plugin-json-3.1.0.tgz",
-      "integrity": "sha512-BlYk5VspvGpjz7lAwArVzBXR60JK+4EKtPkCHouAWg39obk9S61hZYJDBfMK+oitPdoe11i69TlxKlMQNFC/Uw==",
-      "dev": true,
-      "requires": {
-        "rollup-pluginutils": "^2.3.1"
-      }
-    },
     "rollup-plugin-node-resolve": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.4.0.tgz",

--- a/src/support/DatePeriods.js
+++ b/src/support/DatePeriods.js
@@ -115,7 +115,7 @@ class DatePeriods {
     return (
       currentDate.getFullYear() +
       "Q" +
-      this.quarterByMonth(currentDate.getMonth())
+      this.quarterByMonth(currentDate.getMonth() + 1)
     );
   }
 


### PR DESCRIPTION
currentDate.getMonth() returns current human month minus one. Incrementing it by one would make the quarterByMonth function correctly translate the given month into the corresponding quarter