### PR TITLE
Allow cell renderer

### DIFF
--- a/example/src/invoices/demo-chc/Invoice.js
+++ b/example/src/invoices/demo-chc/Invoice.js
@@ -1,7 +1,8 @@
 import React, { Component } from "react";
 import { withStyles } from "@material-ui/core/styles";
 import { Cell } from "@blsq/blsq-report-components";
-
+import DoneIcon from "@material-ui/icons/Done";
+import CloseIcon from "@material-ui/icons/Close";
 const styles = {
   invoiceFrame: {
     backgroundColor: "#ffffff",
@@ -25,6 +26,13 @@ const activity = {
     name: "my super element",
     period: "2016Q4"
   }
+};
+
+const renderer = (value, raw_value) => {
+  if (raw_value == 1) {
+    return <DoneIcon style={{ color: "green" }} />;
+  }
+  return <CloseIcon style={{ color: "red" }} />;
 };
 
 class Invoice extends Component {
@@ -69,6 +77,7 @@ class Invoice extends Component {
                 value={activity}
                 field="total"
                 decimals={0}
+                unit=" $"
               />
             </tr>
             <tr>
@@ -103,6 +112,24 @@ class Invoice extends Component {
                 value={"link to to invoice"}
                 href="./index.html#/invoices/2017Q1/cDw53Ej8rju/demo-chc"
                 bold
+                colSpan={4}
+              />
+            </tr>
+            <tr>
+              <Cell
+                variant="quantity"
+                field="self"
+                value={1}
+                href="https://google.com"
+                renderer={renderer}
+                colSpan={4}
+              />
+              <Cell
+                variant="quantity"
+                field="self"
+                value={0}
+                href="https://google.com"
+                renderer={renderer}
                 colSpan={4}
               />
             </tr>

--- a/src/components/incentives/IncentiveContainer.js
+++ b/src/components/incentives/IncentiveContainer.js
@@ -11,6 +11,7 @@ import IncentiveNavigationBar from "./IncentiveNavigationBar";
 import IncentiveSupport from "./IncentiveSupport";
 import Loader from "../shared/Loader";
 import Warning from "../shared/Warning";
+import DatePeriods from "../../support/DatePeriods";
 
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
@@ -24,7 +25,8 @@ const CustomTableCell = withStyles(theme => ({
     color: theme.palette.common.white,
     textAlign: "center",
     fontWeight: "bold",
-    fontSize: "18px"
+    padding: "5px",
+    fontSize: "14px",
   },
   root: {
     textAlign: "left",
@@ -336,7 +338,12 @@ class IncentiveContainer extends Component {
                 <CustomTableCell>OrgUnit</CustomTableCell>
                 <CustomTableCell>Data element</CustomTableCell>
                 {dsi.periods.map(p => (
-                  <CustomTableCell key={p}>{p}</CustomTableCell>
+                  <CustomTableCell key={p} title={p}>
+                    {DatePeriods.displayName(
+                      p,
+                      this.props.periodFormat[DatePeriods.detect(p)]
+                    )}
+                  </CustomTableCell>
                 ))}
               </TableRow>
             </TableHead>

--- a/src/components/incentives/IncentivePage.js
+++ b/src/components/incentives/IncentivePage.js
@@ -12,6 +12,7 @@ class IncentivePage extends Component {
     return (
       <IncentiveContainer
         period={this.props.match.params.period}
+        periodFormat ={this.props.periodFormat}
         incentiveCode={this.props.match.params.incentiveCode}
         incentivesDescriptors={this.props.incentivesDescriptors}
         currentUser={this.props.currentUser}

--- a/src/components/incentives/IncentiveRoute.js
+++ b/src/components/incentives/IncentiveRoute.js
@@ -10,15 +10,17 @@ const incentiveRoute = props => {
       component={routerProps => (
         <IncentivePage
           {...routerProps}
+          periodFormat={props.periodFormat}
           currentUser={props.currentUser}
           onPeriodChange={props.onPeriodChange}
           incentivesDescriptors={props.incentivesDescriptors}
           dhis2={props.dhis2}
+          {...props.config.global}
+          {...props}
         />
       )}
     />
   );
 };
-
 
 export default incentiveRoute;

--- a/src/components/shared/Cell.js
+++ b/src/components/shared/Cell.js
@@ -92,6 +92,7 @@ const Cell = props => {
     decimals,
     href,
     unit,
+    renderer,
     ...other
   } = props;
   const amount = resolve(field, value);
@@ -150,9 +151,14 @@ const Cell = props => {
   const boldValue = bold === true;
   let renderedValue;
 
-  if (displayedValue && unit) {
-    displayedValue = displayedValue + unit;
+  if (renderer) {
+    displayedValue = renderer(displayedValue, value)
   }
+
+  if (displayedValue && unit) {
+    displayedValue = <React.Fragment>{displayedValue}{unit}</React.Fragment>;
+  }
+
   if (boldValue) {
     renderedValue = <b>{displayedValue}</b>;
   } else {

--- a/src/components/shared/Cell.js
+++ b/src/components/shared/Cell.js
@@ -152,11 +152,11 @@ const Cell = props => {
   let renderedValue;
 
   if (renderer) {
-    displayedValue = renderer(displayedValue, value)
+    displayedValue = renderer(displayedValue, amount);
   }
 
   if (displayedValue && unit) {
-    displayedValue = <React.Fragment>{displayedValue}{unit}</React.Fragment>;
+    displayedValue = displayedValue + unit;
   }
 
   if (boldValue) {

--- a/src/components/shared/Cell.test.js
+++ b/src/components/shared/Cell.test.js
@@ -28,7 +28,6 @@ describe("Cell", () => {
       name: "super",
       period: "2016Q3"
     }
-
   };
 
   it("is truthy", () => {
@@ -50,10 +49,9 @@ describe("Cell", () => {
     expect(tree.toJSON()).toMatchSnapshot();
   });
 
-
   it("renders amount with provided field and unit", () => {
     const tree = TestRenderer.create(
-      <Cell variant="money" field="demo" value={value} unit="$"/>
+      <Cell variant="money" field="demo" value={value} unit="$" />
     );
     expect(tree.toJSON()).toMatchSnapshot();
   });
@@ -74,14 +72,19 @@ describe("Cell", () => {
 
   it("renders percentage with provided field", () => {
     const tree = TestRenderer.create(
-      <Cell variant="percentage" field="score" value={value} unit="%"/>
+      <Cell variant="percentage" field="score" value={value} unit="%" />
     );
     expect(tree.toJSON()).toMatchSnapshot();
   });
 
   it("renders undefined percentage with provided field", () => {
     const tree = TestRenderer.create(
-      <Cell variant="percentage" field="undefinedScore" value={value} unit="%" />
+      <Cell
+        variant="percentage"
+        field="undefinedScore"
+        value={value}
+        unit="%"
+      />
     );
     expect(tree.toJSON()).toMatchSnapshot();
   });
@@ -110,6 +113,43 @@ describe("Cell", () => {
         bold
       />
     );
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  it("renders custom renderer for self", () => {
+    let expect_value;
+    const tree = TestRenderer.create(
+      <Cell
+        variant="title"
+        field="self"
+        value="demo title"
+        renderer={(value, raw_value) => {
+          expect_value = raw_value;
+          return "demo renderer";
+        }}
+      />
+    );
+    expect(expect_value).toEqual("demo title");
+    expect(tree.toJSON()).toMatchSnapshot();
+  });
+
+  it("renders custom renderer for field", () => {
+    let expect_value;
+    let expect_raw_value;
+    const tree = TestRenderer.create(
+      <Cell
+        variant="money"
+        field="demo"
+        value={value}
+        renderer={(displayed_value, raw_value) => {
+          expect_value = displayed_value;
+          expect_raw_value = raw_value;
+          return "demo renderer";
+        }}
+      />
+    );
+    expect(expect_value).toEqual("15,564.52");
+    expect(expect_raw_value).toEqual(value.demo);
     expect(tree.toJSON()).toMatchSnapshot();
   });
 });

--- a/src/components/shared/__snapshots__/Cell.test.js.snap
+++ b/src/components/shared/__snapshots__/Cell.test.js.snap
@@ -18,6 +18,24 @@ exports[`Cell renders amount with provided field and unit 1`] = `
 </td>
 `;
 
+exports[`Cell renders custom renderer for field 1`] = `
+<td
+  className="Cell-cellAmount-5"
+  title="super (demo code)  2016Q3 15564.524"
+>
+  demo renderer
+</td>
+`;
+
+exports[`Cell renders custom renderer for self 1`] = `
+<td
+  className="Cell-cellCenter-7"
+  title=""
+>
+  demo renderer
+</td>
+`;
+
 exports[`Cell renders empty percentage with provided field 1`] = `
 <td
   className="Cell-cellQuantity-4"


### PR DESCRIPTION
allow to do stuff like : 
![image](https://user-images.githubusercontent.com/371692/56794564-b068cd80-680e-11e9-8daf-7eaa4b7cb96d.png)

```js
import DoneIcon from "@material-ui/icons/Done";
import CloseIcon from "@material-ui/icons/Close";
...
const renderer = (value, raw_value) => {
  if (raw_value == 1) {
    return <DoneIcon style={{ color: "green" }} />;
  }
  return <CloseIcon style={{ color: "red" }} />;
};
....

 <Cell
                variant="quantity"
                field="self"
                value={0}
                href="https://google.com"
                renderer={renderer}
                colSpan={4}
              />
...
```

and use the global config to display periods in incentive screen

![image](https://user-images.githubusercontent.com/371692/56794725-09386600-680f-11e9-9fde-3fe941568f43.png)
