### PR TITLE
Support arbitrary format

### DIFF
--- a/src/support/DatePeriods.js
+++ b/src/support/DatePeriods.js
@@ -25,7 +25,20 @@ const QUARTER_BY_SIX_MONTHLY = {
   2: [3, 4]
 };
 
-const MONTH_NAMES_FR = ["Janvier", "Février", "Mars", "Avril", "Mai", "Juin", "Juillet", "Août", "Septembre", "Octobre", "Novembre", "Décembre"];
+const MONTH_NAMES_FR = [
+  "Janvier",
+  "Février",
+  "Mars",
+  "Avril",
+  "Mai",
+  "Juin",
+  "Juillet",
+  "Août",
+  "Septembre",
+  "Octobre",
+  "Novembre",
+  "Décembre"
+];
 
 const MONTH_NAMES_EN = [
   "January",
@@ -84,7 +97,7 @@ const SUPPORTED_FORMATS = [
 ];
 
 class DatePeriods {
-  static setLocale(local){
+  static setLocale(local) {
     const translations = local === "fr" ? MONTH_NAMES_FR : MONTH_NAMES_EN;
     MONTH_NAMES = translations;
     MONTH_NAMES_BY_QUARTER = {
@@ -94,10 +107,10 @@ class DatePeriods {
       "4": [MONTH_NAMES[9], MONTH_NAMES[10], MONTH_NAMES[11]]
     };
     eduQuarterNames = {
-      4: "T1 - "+MONTH_NAMES[8]+" - "+MONTH_NAMES[11],
-      1: "T2 - "+MONTH_NAMES[0]+" - "+MONTH_NAMES[2],
-      2: "T3 - "+MONTH_NAMES[3]+" - "+MONTH_NAMES[5],
-      3: "XX - "+MONTH_NAMES[6]+" - "+MONTH_NAMES[7]
+      4: "T1 - " + MONTH_NAMES[8] + " - " + MONTH_NAMES[11],
+      1: "T2 - " + MONTH_NAMES[0] + " - " + MONTH_NAMES[2],
+      2: "T3 - " + MONTH_NAMES[3] + " - " + MONTH_NAMES[5],
+      3: "XX - " + MONTH_NAMES[6] + " - " + MONTH_NAMES[7]
     };
   }
 
@@ -240,8 +253,62 @@ class DatePeriods {
     } else {
       quarter = quarter - 2;
     }
-
     return "FY " + year + "/" + (year + 1) + " Quarter " + quarter;
+  }
+
+  static formatValues(dhis2period) {
+    const monthDhis2Periods = this.split(dhis2period, MONTHLY);
+    const monthPeriod = monthDhis2Periods[0];
+    const yearPeriod = this.split(dhis2period, YEARLY)[0];
+    const quarterPeriod = this.split(dhis2period, QUARTERLY)[0];
+
+    let year = parseInt(yearPeriod, 0);
+    let quarterNumber = parseInt(quarterPeriod.slice(5), 0);
+    let monthNumber = parseInt(monthPeriod.slice(4), 0);
+    let financialJulyYear = year;
+    let financialQuarterNumber;
+    if (quarterNumber <= 2) {
+      financialJulyYear = year - 1;
+      financialQuarterNumber = quarterNumber + 2;
+    } else {
+      financialQuarterNumber = quarterNumber - 2;
+    }
+    const financialJulyYearPlus1 = financialJulyYear + 1;
+    console.log("before the crash")
+    console.log(monthPeriod)
+    console.log(monthDhis2Periods)
+    const subs = {
+      dhis2period: dhis2period,
+      financialJulyYear: financialJulyYear,
+      financialJulyYearPlus1: financialJulyYearPlus1,
+      year: year,
+      quarterNumber: quarterNumber,
+      financialQuarterNumber: financialQuarterNumber,
+      monthNumber: monthNumber,
+      monthName: this.monthName(monthPeriod),
+      monthQuarterStart: this.monthName(monthDhis2Periods[0]),
+      monthQuarterEnd: this.monthName(monthDhis2Periods[2])
+    };
+
+    return subs;
+  }
+
+  static format(dhis2period, template) {
+    return this.substituteStr(template, this.formatValues(dhis2period));
+  }
+
+  static substituteStr(str, data) {
+    console.log("data", data);
+    var output = str.replace(/(\${([^}]+)})/g, function(match) {
+      let key = match.replace(/\${/, "").replace(/}/, "");
+      console.log("matching", key, data[key]);
+      if (data[key] !== undefined) {
+        return data[key];
+      } else {
+        throw new Error("unknown placeholder :'" + key + "' only knows "+JSON.stringify(data));
+      }
+    });
+    return output;
   }
 
   static next(period) {

--- a/src/support/DatePeriods.test.js
+++ b/src/support/DatePeriods.test.js
@@ -307,6 +307,23 @@ it("period2FinancialYearJulyQuarterName", () => {
   ]);
 });
 
+it("formats", () => {
+  console.log("formats test !!!")
+  expect(
+    DatePeriods.format(
+      "2019Q3",
+      "Financial year ${financialJulyYear}/${financialJulyYearPlus1} - Quarter ${financialQuarterNumber} ${monthQuarterStart}-${monthQuarterEnd}"
+    )
+  ).toEqual("Financial year 2019/2020 - Quarter 1 July-September");
+
+  expect(
+    DatePeriods.format(
+      "201903",
+      "Financial year ${financialJulyYear}/${financialJulyYearPlus1} - Quarter ${financialQuarterNumber} ${monthQuarterStart}-${monthQuarterEnd}"
+    )
+  ).toEqual("");
+});
+
 it("monthYear", () => {
   expect(
     DatePeriods.split("2014", "monthly").map(q =>

--- a/src/support/DatePeriods.test.js
+++ b/src/support/DatePeriods.test.js
@@ -307,23 +307,56 @@ it("period2FinancialYearJulyQuarterName", () => {
   ]);
 });
 
-it("formats", () => {
-  console.log("formats test !!!")
+it("formats quarterly", () => {
   expect(
     DatePeriods.format(
       "2019Q3",
       "Financial year ${financialJulyYear}/${financialJulyYearPlus1} - Quarter ${financialQuarterNumber} ${monthQuarterStart}-${monthQuarterEnd}"
     )
   ).toEqual("Financial year 2019/2020 - Quarter 1 July-September");
-
+  expect(
+    DatePeriods.format(
+      "2019Q2",
+      "Financial year ${financialJulyYear}/${financialJulyYearPlus1} - Quarter ${financialQuarterNumber} ${monthQuarterStart}-${monthQuarterEnd}"
+    )
+  ).toEqual("Financial year 2018/2019 - Quarter 4 April-June");
+});
+it("formats monthly periods", () => {
   expect(
     DatePeriods.format(
       "201903",
-      "Financial year ${financialJulyYear}/${financialJulyYearPlus1} - Quarter ${financialQuarterNumber} ${monthQuarterStart}-${monthQuarterEnd}"
+      " dhis2period: ${dhis2period} " +
+        "financialJulyYear: ${financialJulyYear} " +
+        "financialJulyYearPlus1: ${financialJulyYearPlus1} " +
+        "year: ${year} " +
+        "quarterNumber: ${quarterNumber} " +
+        "financialQuarterNumber: ${financialQuarterNumber} " +
+        "monthNumber: ${monthNumber} " +
+        "monthName: ${monthName} " +
+        "monthQuarterStart: ${monthQuarterStart} " +
+        "monthQuarterEnd: ${monthQuarterEnd} "
     )
-  ).toEqual("");
+  ).toEqual(
+    " dhis2period: 201903 " +
+      "financialJulyYear: 2018 " +
+      "financialJulyYearPlus1: 2019 " +
+      "year: 2019 quarterNumber: 1 " +
+      "financialQuarterNumber: 3 " +
+      "monthNumber: 3 monthName: March " +
+      "monthQuarterStart: January " +
+      "monthQuarterEnd: March "
+  );
 });
-
+it("formats detects unknown token", () => {
+  expect(() => {
+    DatePeriods.format(
+      "201903",
+      " dhis2period: ${dhis2period} ${unknown token}"
+    );
+  }).toThrowError(
+    'unknown placeholder :\'unknown token\' only knows {"dhis2period":"201903","financialJulyYear":2018,"financialJulyYearPlus1":2019,"year":2019,"quarterNumber":1,"financialQuarterNumber":3,"monthNumber":3,"monthName":"March","monthQuarterStart":"January","monthQuarterEnd":"March"}'
+  );
+});
 it("monthYear", () => {
   expect(
     DatePeriods.split("2014", "monthly").map(q =>


### PR DESCRIPTION

Add a format method that take a string template with "known" tokens.

```js
DatePeriods.format(
      "2019Q2",
      "Financial year ${financialJulyYear}/${financialJulyYearPlus1} - Quarter ${financialQuarterNumber} ${monthQuarterStart}-${monthQuarterEnd}"
    )
  ).toEqual("Financial year 2018/2019 - Quarter 4 April-June");
```