### PR TITLE
Show invoicing jobs errors in the invoice toolbar

### DIFF
--- a/src/components/invoices/ErrorsTable.js
+++ b/src/components/invoices/ErrorsTable.js
@@ -1,0 +1,52 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
+import { withNamespaces } from "react-i18next";
+
+const styles = {
+  rowStyle: {
+    verticalAlign: "top",
+    textAlign: "left",
+  },
+};
+
+const ErrorsTable = ({ t, classes, errors, indexedOrgUnits }) => (
+  <div>
+    <h1>{t("invoicing.job.errors")}</h1>
+    <table width="100%" className={classes.rowStyle}>
+      <thead>
+        <tr>
+          <th>{t("invoicing.job.period")}</th>
+          <th>{t("invoicing.job.orgUnit")}</th>
+          <th>{t("invoicing.job.erroredAt")}</th>
+          <th>{t("invoicing.job.error")}</th>
+        </tr>
+      </thead>
+      <tbody>
+        {errors.map((error, index) => {
+          return (
+            <tr key={"error-" + index}>
+              <td>{error.attributes.dhis2Period}</td>
+              <td>
+                {indexedOrgUnits[error.attributes.orgUnit]
+                  ? indexedOrgUnits[error.attributes.orgUnit].name
+                  : error.attributes.orgUnit}
+              </td>
+              <td>{error.attributes.erroredAt.replace("T", " ")}</td>{" "}
+              <td width="60%">{error.attributes.lastError}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  </div>
+);
+
+ErrorsTable.propTypes = {
+  t: PropTypes.func.isRequired,
+  errors: PropTypes.array.isRequired,
+  indexedOrgUnits: PropTypes.object.isRequired,
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(withNamespaces()(ErrorsTable));

--- a/src/components/invoices/InvoiceContainer.js
+++ b/src/components/invoices/InvoiceContainer.js
@@ -67,6 +67,10 @@ class InvoiceContainer extends Component {
       return invoicingJob.attributes.isAlive;
     });
 
+    const errors = invoicingJobs.data.filter((invoicingJob) => {
+      return invoicingJob.attributes.lastError;
+    });
+
     const wasRunning =
       this.state.calculateState && this.state.calculateState.running > 0;
 
@@ -75,6 +79,7 @@ class InvoiceContainer extends Component {
       calculateState: {
         running: runningCount.length,
         total: this.state.invoice.calculations.length,
+        errors: errors
       },
     });
 
@@ -168,9 +173,6 @@ class InvoiceContainer extends Component {
       }
     }
 
-    const locked =
-      currentApprovals.filter((a) => a.mayApprove === true).length === 0;
-    console.log("locked ?", locked);
     console.log(
       "orgunits to approve " + new Set(approvals.map((a) => a.orgUnit)).size
     );
@@ -184,7 +186,6 @@ class InvoiceContainer extends Component {
       lockState: {
         approvals: approvals,
         currentApprovals: currentApprovals,
-        locked: locked,
         stats: stats,
       },
     });
@@ -236,7 +237,7 @@ class InvoiceContainer extends Component {
     await this.loadLockState();
   }
 
-  boolBarButtons = () => {
+  toolBarButtons = () => {
     const calculable = this.props.invoices.isCalculable(
       this.state.invoice,
       this.props.currentUser
@@ -282,13 +283,13 @@ class InvoiceContainer extends Component {
         <PageOrientation
           orientation={this.state.invoice.invoiceType.orientation}
         />
-        {this.boolBarButtons()}
+        {this.toolBarButtons()}
         <SelectedInvoice
           invoice={this.state.invoice}
           orgUnitId={this.props.orgUnitId}
           period={this.props.period}
         />
-        {this.boolBarButtons()}
+        {this.toolBarButtons()}
       </div>
     );
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,5 +67,14 @@
             "title": "Show Columns",
             "titleAria": "Show/Hide Table Columns"
         }
+    },
+    "invoicing": {
+        "job": {
+            "errors":"Error for the last calculate",
+            "period": "Period",
+            "orgUnit": "Org unit",
+            "erroredAt": "When",
+            "error": "Message"
+        }
     }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -67,5 +67,14 @@
             "title": "Colonnes visibles",
             "titleAria": "Montrer/cacher des colonnes"
         }
+    },
+    "invoicing": {
+        "job": {
+            "errors":"Erreurs lors des derniers calculs",
+            "period": "Période",
+            "orgUnit": "Org unit",
+            "erroredAt": "Quand",
+            "error": "Message"
+        }
     }
 }


### PR DESCRIPTION
Since 
- we have now a locking mechanism https://github.com/BLSQ/blsq-report-components/pull/58
- hesabu/orbf2 will be more strict when publishing values to dhis2 : https://github.com/BLSQ/orbf2/pull/194

I wanted to show these errors, in the invoice app.

![invoice-errors](https://user-images.githubusercontent.com/371692/89502355-2bb47f80-d7c5-11ea-8b49-615b5202b39f.gif)
