### PR TITLE
Allow plugins to contribute contract validations

### DIFF
--- a/src/components/contracts/ContractPlugin.js
+++ b/src/components/contracts/ContractPlugin.js
@@ -1,15 +1,17 @@
 import ContractService from "./ContractService";
 import ContractRoutes from "./ContractRoutes";
 import PluginRegistry from "../core/PluginRegistry";
+import DefaultValidator from "./validations/DefaultValidator";
 
 const PROGRAM_FIELDS =
-  "id,name,programStages[programStageDataElements[dataElement[id,name,code,optionSet[id,name,code,options[id,code,name]]]]";
+  "id,name,programStages[programStageDataElements[compulsory,dataElement[id,name,code,optionSet[id,name,code,options[id,code,name]]]]";
 
 class ContractPlugin {
   constructor() {
     this.key = "@blsq/blsq-report-components#contracts";
     this.extensions = {
       "core.routes": [ContractRoutes],
+      "contracts.validator": [DefaultValidator],
     };
   }
 

--- a/src/components/contracts/ContractStatus.js
+++ b/src/components/contracts/ContractStatus.js
@@ -13,7 +13,7 @@ import CheckCircleIcon from "@material-ui/icons/CheckCircle";
 import CancelIcon from "@material-ui/icons/Cancel";
 import InfoIcon from "@material-ui/icons/Info";
 
-const getOverlaps = (contracts) => contracts.map((c) => <div key={c.id}>{`${c.orgUnit.name}, id: ${c.id}`}</div>);
+const getOverlaps = (contracts) => contracts.map((c) => <div key={c.id}>{`${c.orgUnit.name}, id: ${c.id}, ${c.startPeriod} - ${c.endPeriod}`}</div>);
 
 const styles = (theme) => ({
   ...tablesStyles(theme),
@@ -43,7 +43,7 @@ const ContractStatus = ({ contract, t }) => {
   };
   const openPopOver = Boolean(anchorEl);
   const id = openPopOver ? "contract-status" : undefined;
-  const { coverageIssue, nonVisibleOverlaps, visibleOverlaps } = contract.statusDetail;
+  const { coverageIssue, nonVisibleOverlaps, visibleOverlaps , validationErrors } = contract.statusDetail;
   return contract.status ? (
     <CheckCircleIcon className={classNames(classes.success, classes.tableIcon)} />
   ) : (
@@ -64,6 +64,7 @@ const ContractStatus = ({ contract, t }) => {
         }}
       >
         <Box p={2}>
+          {validationErrors.length > 0 && <Box>{validationErrors.map((f) => f.message).join(" ")}</Box>}
           {coverageIssue && <Box>{t("contracts.status.coverageIssue")}</Box>}
           {visibleOverlaps && visibleOverlaps.length > 0 && (
             <Box>

--- a/src/components/contracts/ContractsDialog.js
+++ b/src/components/contracts/ContractsDialog.js
@@ -69,12 +69,15 @@ const ContractsDialog = ({
 
   const contractService = PluginRegistry.extension("contracts.service");
   const [currentContract, setCurrentContract] = React.useState(contract);
+  const [validationErrors, setValidationErrors] = React.useState([]);
   const isLoading = useSelector((state) => state.load.isLoading);
   const classes = useStyles();
   const dispatch = useDispatch();
 
   useEffect(() => {
+    const errors = contractService.validateContract(contract);
     setCurrentContract(contract);
+    setValidationErrors(errors);
   }, [contract]);
   const handleClickOpen = () => {
     setOpen(true);
@@ -83,7 +86,7 @@ const ContractsDialog = ({
     setOpen(false);
   };
   const handleChange = (key, value, subKey) => {
-    setCurrentContract({
+    const updatedContract = {
       ...currentContract,
       [key]: !subKey
         ? value
@@ -91,7 +94,11 @@ const ContractsDialog = ({
             ...currentContract[key],
             [subKey]: value,
           },
-    });
+    };
+    const errors = contractService.validateContract(updatedContract);
+
+    setCurrentContract(updatedContract);
+    setValidationErrors(errors);
   };
   const handleSave = () => {
     dispatch(setIsLoading(true));
@@ -146,6 +153,9 @@ const ContractsDialog = ({
           <IconButton className={classes.closeButton} onClick={handleClose}>
             <CloseIcon />
           </IconButton>
+          {validationErrors.length > 0 && (
+            <span style={{ color: "red" }}>{validationErrors.map((err) => err.message).join(" ")}</span>
+          )}
         </DialogTitle>
         <DialogContent dividers>
           <Grid container spacing={2}>

--- a/src/components/contracts/DeleteContractDialog.js
+++ b/src/components/contracts/DeleteContractDialog.js
@@ -1,0 +1,106 @@
+import React from "react";
+import { withTranslation } from "react-i18next";
+import {
+  Button,
+  Dialog,
+  Tooltip,
+  IconButton,
+  Typography,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  makeStyles,
+} from "@material-ui/core";
+import PluginRegistry from "../core/PluginRegistry";
+import { enqueueSnackbar } from "../redux/actions/snackBars";
+import { errorSnackBar, succesfullSnackBar } from "../shared/snackBars/snackBar";
+import CloseIcon from "@material-ui/icons/Close";
+import DeleteIcon from "@material-ui/icons/Delete";
+import { useDispatch, useSelector } from "react-redux";
+import { setIsLoading } from "../redux/actions/load";
+
+const styles = (theme) => ({
+  title: {
+    width: "80%",
+  },
+  deleteButton: {
+    marginLeft: theme.spacing(4),
+  },
+  closeButton: {
+    position: "absolute",
+    right: theme.spacing(1),
+    top: theme.spacing(1),
+    color: theme.palette.grey[500],
+  },
+  label: {
+    paddingTop: 4,
+  },
+});
+
+const useStyles = makeStyles((theme) => styles(theme));
+
+const DeleteContractDialog = ({ t, contract, onSavedSuccessfull }) => {
+
+  const contractService = PluginRegistry.extension("contracts.service");
+
+  const classes = useStyles();
+  const [open, setOpen] = React.useState(false);
+  const dispatch = useDispatch();
+  const isLoading = useSelector((state) => state.load.isLoading);
+
+
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+  const handleClose = () => {
+    setOpen(false);
+  };
+  const handleSave = () => {
+    setOpen(false);
+    dispatch(setIsLoading(true));
+    const deleteContract = contractService.deleteContract(contract);
+    deleteContract
+      .then(() => {
+        dispatch(setIsLoading(false));
+        onSavedSuccessfull();
+        dispatch(enqueueSnackbar(succesfullSnackBar("snackBar.success.save")));
+      })
+      .catch((err) => {
+        setIsLoading(false);
+        dispatch(enqueueSnackbar(errorSnackBar("snackBar.error.save", null, err)));
+      });
+  };
+
+  return (
+    <>
+      <Tooltip onClick={() => handleClickOpen()} placement="bottom" title={t("delete")} arrow>
+        <span className={classes.deleteButton}>
+          <IconButton size="small">
+            <DeleteIcon />
+          </IconButton>
+        </span>
+      </Tooltip>
+
+      <Dialog onClose={handleClose} open={open} fullWidth maxWidth="sm">
+        <DialogTitle disableTypography>
+          <Typography variant="h6" className={classes.title}>
+            {t("contracts.deleteTitle")}
+          </Typography>
+          <IconButton className={classes.closeButton} onClick={handleClose}>
+            <CloseIcon />
+          </IconButton>
+        </DialogTitle>
+
+        <DialogContent>{t("contracts.deleteWarning")}</DialogContent>
+
+        <DialogActions>
+          <Button autoFocus onClick={handleSave} color="primary" disabled={isLoading}>
+            {t("delete")}
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+export default withTranslation()(DeleteContractDialog);

--- a/src/components/contracts/config.js
+++ b/src/components/contracts/config.js
@@ -8,6 +8,7 @@ import { defaultOptions } from "../../support/table";
 import OrgUnitIcon from "../shared/icons/OrgUnitIcon";
 import ContractStatus from "./ContractStatus";
 import { getOrgUnitAncestors, getOptionFromField, getContractByOrgUnit } from "./utils/index";
+import DeleteContractDialog from "./DeleteContractDialog";
 
 export const contractsTableColumns = (
   t,
@@ -165,6 +166,8 @@ export const contractsTableColumns = (
               displayOrgUnit={displayOrgUnit}
               displayMainOrgUnit={displayMainOrgUnit}
             />
+            {isDetail && <DeleteContractDialog contract={contract} onSavedSuccessfull={fetchContracts} />}
+
             {!isDetail && (
               <Tooltip placement="bottom" title={t("contracts.seeOrgUnit")} arrow>
                 <Link

--- a/src/components/contracts/validations/DefaultValidator.js
+++ b/src/components/contracts/validations/DefaultValidator.js
@@ -1,0 +1,18 @@
+const isEmpty = (value) => {
+  return value == undefined || value == "" || value == null;
+};
+const DefaultValidator = (contract, context) => {
+  const missingFields = context.contractFields.filter(
+    (field) => field.compulsory && isEmpty(contract.fieldValues[field.code]),
+  );
+
+  return missingFields.map((field) => {
+    return {
+      field: field.code,
+      errorCode: "required",
+      message: context.t("validations.isrequired", { interpolation: true, field: field.name }),
+    };
+  });
+};
+
+export default DefaultValidator;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,10 +27,13 @@
         "subContractCoveragesWarningSingle": "Sub contract {{rowIndex}} is more large than the main contract coverage",
         "subContractNotVisibleOverlap": "Sub contract {{rowIndex}} overlaps with {{count}} contract(s) not visible on this page",
         "subContracts": "Sub contract(s)",
-        "title": "Contracts"
+        "title": "Contracts",
+        "deleteTitle": "Delete contract",
+        "deleteWarning": "This will only delete the contract, data generated based on these infos will remain. If subcontracted orgunits reference this contract, delete/update them first."
     },
     "create": "Create",
     "edit": "Edit",
+    "delete": "Delete",
     "end_period": "End",
     "filter": "Filter",
     "generated_at": "Generated on",
@@ -110,5 +113,8 @@
             "title": "Show Columns",
             "titleAria": "Show/Hide Table Columns"
         }
+    },
+    "validations": {
+        "isrequired": "{{field}} is required"
     }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -24,10 +24,13 @@
             "visibleOverlaps": "Ce contrat se chevauche avec {{count}} contrat(s)"
         },
         "subContracts": "Sous-contrat(s)",
-        "title": "Contrats"
+        "title": "Contrats",
+        "deleteTitle": "Suppression du contrat",
+        "deleteWarning": "La suppression du contrat n'a aucune influence sur les données qui étaient liées à ce contrat. Si il y a des sous-contrats liés à ce contrat, supprimez ou mettez à jour ceux-ci d'abord."
     },
     "create": "Créer",
     "edit": "Editer",
+    "delete": "Supprimer",
     "end_period": "Fin",
     "filter": "Filtrer",
     "generated_at": "Généré le",
@@ -107,5 +110,8 @@
             "title": "Colonnes visibles",
             "titleAria": "Montrer/cacher des colonnes"
         }
+    },
+    "validations": {
+        "isrequired": "{{field}} est obligatoire"
     }
 }


### PR DESCRIPTION
The plugin can register extra validation rules via

```
extensions: {
   "contracts.validator": [DefaultValidator]
}
```

The validator is supposed to return an array of validation errors that looks like

```
(contract, context) => {
 return [
    {
      field: field.code,
      errorCode: "required",
      message: context.t("validations.isrequired", { interpolation: true, field: field.name }),
    }
   ]
```
translation are in the i18n stuff.

there are displayed in the table 
![image](https://user-images.githubusercontent.com/371692/100245203-12803c00-2f38-11eb-8a85-17679e34bdb6.png)
or the edit dialog
![image](https://user-images.githubusercontent.com/371692/100245258-21ff8500-2f38-11eb-94e9-7ceb1a80f659.png)

a next step might be to move other validations, but overlaps is more harder (requires more info in the context)

I also added the support to delete (eg on overlapping contract the solution can be to delete a duplicate and edit the other )
this is only available on the orgunit view

![image](https://user-images.githubusercontent.com/371692/100246185-24161380-2f39-11eb-88c5-04b3dff1f53e.png)


a confirmation dialog is showed

![image](https://user-images.githubusercontent.com/371692/100246083-09439f00-2f39-11eb-97c9-4bea377f2ba3.png)
