### PR TITLE
Create a specific period picker for contracts encoding

### DIFF
--- a/src/components/contracts/ContractsDialog.js
+++ b/src/components/contracts/ContractsDialog.js
@@ -16,11 +16,10 @@ import {
 import CloseIcon from "@material-ui/icons/Close";
 import Edit from "@material-ui/icons/Edit";
 import { useDispatch, useSelector } from "react-redux";
-
+import PeriodPicker from "./PeriodPicker"
 import PluginRegistry from "../core/PluginRegistry";
 
 import OuSearch from "../shared/OuSearch";
-import PeriodPicker from "../shared/PeriodPicker";
 import { errorSnackBar, succesfullSnackBar } from "../shared/snackBars/snackBar";
 import { setIsLoading } from "../redux/actions/load";
 
@@ -29,10 +28,7 @@ import { getNonStandartContractFields, getContractByOrgUnit } from "./utils/inde
 
 import {
   getStartDateFromPeriod,
-  getEndDateFromPeriod,
-  getQuarterFromDate,
-  getStartMonthFromQuarter,
-  getEndMonthFromQuarter,
+  getEndDateFromPeriod,  
 } from "./utils/periodsUtils";
 import { enqueueSnackbar } from "../redux/actions/snackBars";
 
@@ -178,23 +174,23 @@ const ContractsDialog = ({
             )}
             <Grid container item xs={6}>
               <PeriodPicker
-                periodDelta={{ before: 20, after: 20 }}
-                period={getQuarterFromDate(currentContract.fieldValues.contract_start_date)}
-                max={getQuarterFromDate(currentContract.fieldValues.contract_end_date)}
-                renderPeriod={(p) => `${getStartMonthFromQuarter(p)} ${p.substring(0, 4)}`}
-                labelKey="start_period"
+                contract={currentContract}
+                currentPeriod={currentContract.startPeriod}
+                max={currentContract.endPeriod}
+                mode="beginning"
+                fieldName={t("start_period")}
                 onPeriodChange={(startPeriod) =>
                   handleChange("fieldValues", getStartDateFromPeriod(startPeriod), "contract_start_date")
                 }
               />
             </Grid>
             <Grid container item xs={6}>
-              <PeriodPicker
-                periodDelta={{ before: 20, after: 20 }}
-                period={getQuarterFromDate(currentContract.fieldValues.contract_end_date)}
-                renderPeriod={(p) => `${getEndMonthFromQuarter(p)} ${p.substring(0, 4)}`}
-                labelKey="end_period"
-                min={getQuarterFromDate(currentContract.fieldValues.contract_start_date)}
+            <PeriodPicker
+                contract={currentContract}
+                currentPeriod={currentContract.endPeriod}
+                min={currentContract.startPeriod}
+                fieldName={t("end_period")}
+                mode="end"
                 onPeriodChange={(endPeriod) =>
                   handleChange("fieldValues", getEndDateFromPeriod(endPeriod), "contract_end_date")
                 }

--- a/src/components/contracts/PeriodPicker.js
+++ b/src/components/contracts/PeriodPicker.js
@@ -1,106 +1,111 @@
 import { FormControl, TextField, makeStyles } from "@material-ui/core";
 import { Autocomplete, createFilterOptions } from "@material-ui/lab";
 import React, { useState } from "react";
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from "react-i18next";
 import DatePeriods from "../../support/DatePeriods";
 import PropTypes from "prop-types";
 
 const styles = (theme) => ({
-    formControl: {
-        width: "100%",
-        marginBottom: theme.spacing(),
-        flexDirection: "row",
-        alignItems: "center",
-        position: "relative",
-    },
-    input: {
-        width: "100%",
-    },
+  formControl: {
+    width: "100%",
+    marginBottom: theme.spacing(),
+    flexDirection: "row",
+    alignItems: "center",
+    position: "relative",
+  },
+  input: {
+    width: "100%",
+  },
 });
 const useStyles = makeStyles((theme) => styles(theme));
 
-const minYear = 1970
+const minYear = 1970;
 const maxYear = new Date().getFullYear() + 40;
 
-
 const PeriodPicker = ({ currentPeriod, mode, fieldName, min, max, onPeriodChange }) => {
+  const indexOfMonth = mode === "beginning" ? 0 : 2;
+  const classes = useStyles();
+  const { t } = useTranslation();
+  const defaultPeriod = currentPeriod || "" + new Date().getFullYear() + (mode == "beginning" ? "01" : "12");
 
-    const indexOfMonth = mode == "beginning" ? 0 : 2
-    const classes = useStyles();
-    const { t, i18n } = useTranslation();
-    const defaultPeriod = currentPeriod || "" + new Date().getFullYear() + (mode == "beginning" ? "01" : "12")
+  const [period, setPeriod] = useState(undefined);
 
-    const [period, setPeriod] = useState(undefined)
-
-    const visibibleQuarters = []
-    let year = minYear
-    while (year <= maxYear) {
-        DatePeriods.split("" + year, "quarterly").forEach(p => visibibleQuarters.push(p))
-        year = year + 1
-    }
-    const visibleMonths = visibibleQuarters.map(period => {
-        const monthPeriod = DatePeriods.split(period, "monthly")[indexOfMonth]
-        return { value: monthPeriod, label: DatePeriods.displayName(monthPeriod, "monthYear"), monthPeriod: monthPeriod, quarterPeriod: period } // +" / "+
-    }).filter(p => {
-        if (min && p.monthPeriod < min) {
-            return false
-        }
-        if (max && p.monthPeriod >= max) {
-            return false
-        }
-        return true
+  const visibibleQuarters = [];
+  let year = minYear;
+  while (year <= maxYear) {
+    DatePeriods.split("" + year, "quarterly").forEach((p) => visibibleQuarters.push(p));
+    year = year + 1;
+  }
+  const visibleMonths = visibibleQuarters
+    .map((period) => {
+      const monthPeriod = DatePeriods.split(period, "monthly")[indexOfMonth];
+      return {
+        value: monthPeriod,
+        label: DatePeriods.displayName(monthPeriod, "monthYear"),
+        monthPeriod: monthPeriod,
+        quarterPeriod: period,
+      }; // +" / "+
     })
-    const handleChange = (newperiod) => {
-        setPeriod(newperiod)
-        onPeriodChange(newperiod ? newperiod.monthPeriod : undefined)
-    }
-
-    const filterOptions = createFilterOptions({
-        /* this allow to filter by typing 201601 or 20216Q1 or janvier 20...*/
-        stringify: option => {
-            return option.label + " " + option.monthPeriod + " " + option.quarterPeriod
-        }
+    .filter((p) => {
+      if (min && p.monthPeriod < min) {
+        return false;
+      }
+      if (max && p.monthPeriod >= max) {
+        return false;
+      }
+      return true;
     });
-    const current = visibleMonths.filter(v => v.monthPeriod == defaultPeriod)
+  const handleChange = (newperiod) => {
+    setPeriod(newperiod);
+    onPeriodChange(newperiod ? newperiod.monthPeriod : undefined);
+  };
 
-    return <FormControl >
-        <Autocomplete
-            fullWidth
-            noOptionsText={t("noResult")}
-            multiple={false}
-            value={period}
-            defaultValue={current[0]}
-            options={visibleMonths}
-            getOptionLabel={(option) => option.label}
-            filterOptions={filterOptions}
-            onChange={(event, newValue) => handleChange(newValue)}
+  const filterOptions = createFilterOptions({
+    /* this allow to filter by typing 201601 or 20216Q1 or janvier 20... */
+    stringify: (option) => {
+      return option.label + " " + option.monthPeriod + " " + option.quarterPeriod;
+    },
+  });
+  const current = visibleMonths.filter((v) => v.monthPeriod === defaultPeriod);
 
-            renderInput={(params) => (
-                <TextField
-                    {...params}
-                    label={fieldName}
-                    InputProps={{
-                        ...params.InputProps,
-                        className: classes.input,
-                    }}
-                    InputLabelProps={{
-                        className: classes.label,
-                    }}
-                    placeholder=""
-                />
-            )}
-        />
+  return (
+    <FormControl>
+      <Autocomplete
+        fullWidth
+        noOptionsText={t("noResult")}
+        multiple={false}
+        value={period}
+        defaultValue={current[0]}
+        options={visibleMonths}
+        getOptionLabel={(option) => option.label}
+        filterOptions={filterOptions}
+        onChange={(event, newValue) => handleChange(newValue)}
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label={fieldName}
+            InputProps={{
+              ...params.InputProps,
+              className: classes.input,
+            }}
+            InputLabelProps={{
+              className: classes.label,
+            }}
+            placeholder=""
+          />
+        )}
+      />
     </FormControl>
-}
-
-
-PeriodPicker.propTypes = {
-    currentPeriod: PropTypes.string,
-    mode: PropTypes.oneOf(['beginning', 'end']),
-    fieldName: PropTypes.func.isRequired,
-    min: PropTypes.string,
-    max: PropTypes.string,
-    onPeriodChange: PropTypes.func.isRequired
+  );
 };
 
-export default PeriodPicker
+PeriodPicker.propTypes = {
+  currentPeriod: PropTypes.string,
+  mode: PropTypes.oneOf(["beginning", "end"]),
+  fieldName: PropTypes.string.isRequired,
+  min: PropTypes.string,
+  max: PropTypes.string,
+  onPeriodChange: PropTypes.func.isRequired,
+};
+
+export default PeriodPicker;

--- a/src/components/contracts/PeriodPicker.js
+++ b/src/components/contracts/PeriodPicker.js
@@ -3,6 +3,7 @@ import { Autocomplete, createFilterOptions } from "@material-ui/lab";
 import React, { useState } from "react";
 import { useTranslation } from 'react-i18next';
 import DatePeriods from "../../support/DatePeriods";
+import PropTypes from "prop-types";
 
 const styles = (theme) => ({
     formControl: {
@@ -51,7 +52,7 @@ const PeriodPicker = ({ currentPeriod, mode, fieldName, min, max, onPeriodChange
     })
     const handleChange = (newperiod) => {
         setPeriod(newperiod)
-        onPeriodChange(newperiod.monthPeriod)
+        onPeriodChange(newperiod ? newperiod.monthPeriod : undefined)
     }
 
     const filterOptions = createFilterOptions({
@@ -95,7 +96,7 @@ const PeriodPicker = ({ currentPeriod, mode, fieldName, min, max, onPeriodChange
 
 PeriodPicker.propTypes = {
     currentPeriod: PropTypes.string,
-    mode: PropTypes.string.oneOf(['beginning', 'end']),
+    mode: PropTypes.oneOf(['beginning', 'end']),
     fieldName: PropTypes.func.isRequired,
     min: PropTypes.string,
     max: PropTypes.string,

--- a/src/components/contracts/PeriodPicker.js
+++ b/src/components/contracts/PeriodPicker.js
@@ -1,0 +1,105 @@
+import { FormControl, TextField, makeStyles } from "@material-ui/core";
+import { Autocomplete, createFilterOptions } from "@material-ui/lab";
+import React, { useState } from "react";
+import { useTranslation } from 'react-i18next';
+import DatePeriods from "../../support/DatePeriods";
+
+const styles = (theme) => ({
+    formControl: {
+        width: "100%",
+        marginBottom: theme.spacing(),
+        flexDirection: "row",
+        alignItems: "center",
+        position: "relative",
+    },
+    input: {
+        width: "100%",
+    },
+});
+const useStyles = makeStyles((theme) => styles(theme));
+
+const minYear = 1970
+const maxYear = new Date().getFullYear() + 40;
+
+
+const PeriodPicker = ({ currentPeriod, mode, fieldName, min, max, onPeriodChange }) => {
+
+    const indexOfMonth = mode == "beginning" ? 0 : 2
+    const classes = useStyles();
+    const { t, i18n } = useTranslation();
+    const defaultPeriod = currentPeriod || "" + new Date().getFullYear() + (mode == "beginning" ? "01" : "12")
+
+    const [period, setPeriod] = useState(undefined)
+
+    const visibibleQuarters = []
+    let year = minYear
+    while (year <= maxYear) {
+        DatePeriods.split("" + year, "quarterly").forEach(p => visibibleQuarters.push(p))
+        year = year + 1
+    }
+    const visibleMonths = visibibleQuarters.map(period => {
+        const monthPeriod = DatePeriods.split(period, "monthly")[indexOfMonth]
+        return { value: monthPeriod, label: DatePeriods.displayName(monthPeriod, "monthYear"), monthPeriod: monthPeriod, quarterPeriod: period } // +" / "+
+    }).filter(p => {
+        if (min && p.monthPeriod < min) {
+            return false
+        }
+        if (max && p.monthPeriod >= max) {
+            return false
+        }
+        return true
+    })
+    const handleChange = (newperiod) => {
+        setPeriod(newperiod)
+        onPeriodChange(newperiod.monthPeriod)
+    }
+
+    const filterOptions = createFilterOptions({
+        /* this allow to filter by typing 201601 or 20216Q1 or janvier 20...*/
+        stringify: option => {
+            return option.label + " " + option.monthPeriod + " " + option.quarterPeriod
+        }
+    });
+    const current = visibleMonths.filter(v => v.monthPeriod == defaultPeriod)
+
+    return <FormControl >
+        <Autocomplete
+            fullWidth
+            noOptionsText={t("noResult")}
+            multiple={false}
+            value={period}
+            defaultValue={current[0]}
+            options={visibleMonths}
+            getOptionLabel={(option) => option.label}
+            filterOptions={filterOptions}
+            onChange={(event, newValue) => handleChange(newValue)}
+
+            renderInput={(params) => (
+                <TextField
+                    {...params}
+                    label={fieldName}
+                    InputProps={{
+                        ...params.InputProps,
+                        className: classes.input,
+                    }}
+                    InputLabelProps={{
+                        className: classes.label,
+                    }}
+                    placeholder=""
+                />
+            )}
+        />
+    </FormControl>
+}
+
+
+PeriodPicker.propTypes = {
+    currentPeriod: PropTypes.string,
+    mode: PropTypes.string.oneOf(['beginning', 'end']),
+    fieldName: PropTypes.func.isRequired,
+    min: PropTypes.string,
+    max: PropTypes.string,
+    onPeriodChange: PropTypes.func.isRequired
+};
+
+export default PeriodPicker

--- a/src/components/contracts/utils/periodsUtils.js
+++ b/src/components/contracts/utils/periodsUtils.js
@@ -12,10 +12,16 @@ export const getEndMonthFromQuarter = (endPeriod) => {
 };
 
 export const getStartDateFromPeriod = (startPeriod) => {
+  if (startPeriod == undefined) {
+    return undefined
+  }
   const startPeriodMonths = DatePeriods.split(startPeriod, "monthly");
   return moment(startPeriodMonths[0], "YYYYMM").format("YYYY-MM-DD");
 };
 export const getEndDateFromPeriod = (endPeriod) => {
+  if (endPeriod == undefined) {
+    return undefined
+  }  
   const endPeriodMonths = DatePeriods.split(endPeriod, "monthly");
   return moment(endPeriodMonths[endPeriodMonths.length - 1], "YYYYMM")
     .endOf("month")


### PR DESCRIPTION

* use autocomplete instead of select :
    * improve typing (the previous version was making hard to select janvier 1996)
    * you can filter on the text ( janvier 2016), on dhis2 period format (201601 or 2016Q3)
* use DatePeriods ensure a bit of compatibility in "period calculations" (eg ethiopia)


![periodPicker](https://user-images.githubusercontent.com/371692/107856224-0f099c00-6e27-11eb-81a4-571af5c87534.gif)
