### PR TITLE
Allow cross contracts validations

### DIFF
--- a/src/components/contracts/ContractService.js
+++ b/src/components/contracts/ContractService.js
@@ -205,6 +205,7 @@ class ContractService {
           nonVisibleOverlaps,
           visibleOverlaps,
           validationErrors,
+          warnings: validationErrors.map((err) => err.message).join("\n"),
         };
         c.rowIndex = i + 1;
       });
@@ -215,6 +216,7 @@ class ContractService {
         c.statusDetail = {
           visibleOverlaps,
           validationErrors,
+          warnings: validationErrors.map((err) => err.message).join("\n"),
         };
         c.rowIndex = i + 1;
       });
@@ -237,12 +239,13 @@ class ContractService {
     const contractsOverlaps = this.toOverlappings(contracts);
     const contractsById = this.toContractsById(contracts);
     contracts.forEach((c) => {
-      const validationErrors = this._validate(validators, c, { contractFields, t });
+      const validationErrors = this._validate(validators, c, { contractFields, t, contracts });
       const visibleOverlaps = getOverlaps(c.id, contractsOverlaps, contractsById);
       c.status = visibleOverlaps.length === 0 && validationErrors.length === 0;
       c.statusDetail = {
         visibleOverlaps,
         validationErrors,
+        warnings: validationErrors.map((err) => err.message).join("\n"),
       };
     });
 
@@ -269,16 +272,16 @@ class ContractService {
         if (dataElement === undefined) {
           throw new Error(
             "no mapping for field " +
-            fieldKey +
-            " vs " +
-            Object.values(this.mappings)
-              .map((m) => m.code)
-              .join(","),
+              fieldKey +
+              " vs " +
+              Object.values(this.mappings)
+                .map((m) => m.code)
+                .join(","),
           );
         }
-        let value = contractInfo[fieldKey]
+        let value = contractInfo[fieldKey];
         if (dataElement.code == "contract_main_orgunit" && value && value.id) {
-          value = value.id
+          value = value.id;
         }
         dataValues.push({
           dataElement: dataElement.id,

--- a/src/components/contracts/ContractsResume.js
+++ b/src/components/contracts/ContractsResume.js
@@ -18,7 +18,6 @@ const ContractResume = ({ contracts, filteredContracts, overlapsTotal, t }) => {
   const classes = useStyles();
   const [showStats, setShowStats] = React.useState(false);
   const warningsTotal = filteredContracts.filter((c) => c.statusDetail && c.statusDetail.warnings != "").length;
-  debugger;
   if (contracts.length === 0) return "";
   return (
     <>

--- a/src/components/contracts/ContractsResume.js
+++ b/src/components/contracts/ContractsResume.js
@@ -8,7 +8,6 @@ import { IconButton } from "@material-ui/core";
 import InfoIcon from "@material-ui/icons/Info";
 import ContractsStats from "./ContractsStats";
 
-
 const styles = (theme) => ({
   ...tablesStyles(theme),
 });
@@ -18,6 +17,8 @@ const useStyles = makeStyles((theme) => styles(theme));
 const ContractResume = ({ contracts, filteredContracts, overlapsTotal, t }) => {
   const classes = useStyles();
   const [showStats, setShowStats] = React.useState(false);
+  const warningsTotal = filteredContracts.filter((c) => c.statusDetail && c.statusDetail.warnings != "").length;
+  debugger;
   if (contracts.length === 0) return "";
   return (
     <>
@@ -31,6 +32,7 @@ const ContractResume = ({ contracts, filteredContracts, overlapsTotal, t }) => {
             filtered: filteredContracts.length,
             total: contracts.length,
           })}
+        {warningsTotal > 0 && ", "+t("contracts.invalids", { warnings: warningsTotal })}
         {overlapsTotal > 0 && t("contracts.overlaps", { overlap: overlapsTotal })}.
       </span>
       <IconButton

--- a/src/components/contracts/config.js
+++ b/src/components/contracts/config.js
@@ -55,6 +55,20 @@ export const contractsTableColumns = (
         customBodyRenderLite: (dataIndex) => <ContractStatus contract={filteredContracts[dataIndex]} />,
       },
     },
+
+    {
+      name: "statusDetail.warnings",
+      label: t("contracts.warnings"),
+      options: {
+        filter: false,
+        display: false,
+        sort: true,
+        setCellHeaderProps: () => ({
+          className: classNames(classes.cellCentered, classes.headerCell),
+        }),
+        customBodyRenderLite: (dataIndex) => <div>{filteredContracts[dataIndex].statusDetail.validationErrors.map(err => err.message).join("\n") }</div>,
+      },
+    },    
     {
       name: "orgUnit.name",
       label: t("orgUnit_name"),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,6 +13,7 @@
     "onlySubContracts": "Only sub contracts",
     "overlappingWith": "Overlaps with",
     "overlaps": ", {{overlap}} overlapping globaly",
+    "invalids": " {{warnings}} invalids",
     "result": "1 contract",
     "results": "{{total}} contracts",
     "resultsFiltered": "{{filtered}} results filtered out {{total}} contracts",
@@ -31,7 +32,8 @@
     "deleteTitle": "Delete contract",
     "deleteWarning": "This will only delete the contract, data generated based on these infos will remain. If subcontracted orgunits reference this contract, delete/update them first.",
     "contract_main_orgunit_id": "Main org unit id",
-    "massUpdate": "Mass Update"
+    "massUpdate": "Mass Update",
+    "warnings": "Warnings"
   },
   "dataEntry":{
     "contractFrom": "Contract from",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -14,6 +14,7 @@
     "onlySubContracts": "Seulement les sous contrats",
     "overlappingWith": "Se chevauchant avec",
     "overlaps": ", dont {{overlap}} se chevauchant",
+    "invalids": " {{warnings}} invalides",
     "result": "1 contrat",
     "results": "{{total}} contrats",
     "resultsFiltered": "{{filtered}} contrats filtrés sur {{total}}",
@@ -29,7 +30,8 @@
     "deleteTitle": "Suppression du contrat",
     "deleteWarning": "La suppression du contrat n'a aucune influence sur les données qui étaient liées à ce contrat. Si il y a des sous-contrats liés à ce contrat, supprimez ou mettez à jour ceux-ci d'abord.",
     "contract_main_orgunit_id": "Id de l'unité d'organisation principale",
-    "massUpdate": "Update en masse"
+    "massUpdate": "Update en masse",
+    "warnings": "Warnings"
   },
   "dataEntry":{
     "contractFrom": "Contract de",


### PR DESCRIPTION
Allow the validator to check contracts, not all places will pass the context.contracts 

(this one might need some tuning, not checking against periods, or be reversed check if a cas in bundled in the zone témoins)

```

  if (context.contracts && isZoneTemoin) {
    const contractsInZoneNotTemoin = context.contracts.filter(
      (c) =>
        c.orgUnit.path.includes(contract.orgUnit.id) &&
        isIn(c, "evaluation_d_impact", EVALIMPACT_NON_TEMOIN)
    );
    console.log(contractsInZoneNotTemoin);
    if (contractsInZoneNotTemoin.length > 0) {
      errors.push({
        field: "zones_pdss_pvsbg",
        errorCode: "required",
        message:
          "Une zone témoin ne peut contenir des orgunits cas : " +
          contractsInZoneNotTemoin.map((c) => c.orgUnit.name+" ("+c.orgUnit.id+")").join(" , "),
      });
    }
  }

```
You can optionally see the warnings (currently only the one coming from the validators), and download them in the csv


![image](https://user-images.githubusercontent.com/371692/110791532-9efa0480-8272-11eb-8095-1a1713fe6c66.png)


