### PR TITLE
Display stats for selection

### DIFF
--- a/src/components/completeness/CompletionInfo.js
+++ b/src/components/completeness/CompletionInfo.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+
+function getColor(value) {
+  //value from 0 to 100
+  var hue = ((value / 100) * 120).toString(10);
+  return ["hsl(", hue, ",50%,50%)"].join("");
+}
+
+const CompletionInfo = ({ ratio, completed, expected }) => {
+  const color = getColor(ratio);
+  return (
+    <span style={{ color: color }}>
+      <b title="completion ratio = completed / expected">{ratio}</b> %<br></br>
+      <span title="completed / expected">{completed + "/" + expected}</span>
+    </span>
+  );
+};
+
+export default CompletionInfo;


### PR DESCRIPTION
reuse the same components in to display the ratio (in per orgunit (no more individual columns) and per zone and total )
![image](https://user-images.githubusercontent.com/371692/118470711-37938180-b707-11eb-94d3-e3f5fc99e7f0.png)

and display total on filtered

![image](https://user-images.githubusercontent.com/371692/118470559-129f0e80-b707-11eb-8562-08811b52af27.png)
