### PR TITLE
Completness multiple forms

### DIFF
--- a/src/components/completeness/CompletenessView.js
+++ b/src/components/completeness/CompletenessView.js
@@ -1,337 +1,52 @@
 import { DatePeriods, PluginRegistry } from "@blsq/blsq-report-components";
-import CompletionInfo from "./CompletionInfo";
 import _ from "lodash";
 import MUIDataTable from "mui-datatables";
 import React, { useEffect } from "react";
-import { TableCell, TableRow } from "@material-ui/core";
 import PortalHeader from "../shared/PortalHeader";
 import PeriodPicker from "../shared/PeriodPicker";
 import { Typography } from "@material-ui/core";
 
-const tableOptions = (quarterPeriod) => {
-  return {
-    enableNestedDataAccess: ".",
-    print: false,
-    rowsPerPage: 50,
-    rowsPerPageOptions: [1, 5, 10, 20, 50, 100, 1000],
-    downloadOptions: {
-      filename: "orgunit-completeness-" + quarterPeriod,
-      separator: ",",
-    },
-  };
-};
+import { toCompleteness, buildStatsByZone } from "./calculations";
+import { orgUnitColumns, zoneStatsColumns, statsTableOptions, tableOptions } from "./tables";
 
-const statsTableOptions = (quarterPeriod, statsByZone, setSelectedZones) => {
-  return {
-    enableNestedDataAccess: ".",
-    print: false,
-    rowsPerPage: 5,
-    rowsPerPageOptions: [1, 5, 10, 20, 50, 100, 1000],
-    downloadOptions: {
-      filename: "zone-completeness-" + quarterPeriod,
-      separator: ",",
-    },
-    onRowSelectionChange: (_currentRowsSelected, _allRowsSelected, rowsSelected) => {
-      const selectedZones = rowsSelected.map((index) => statsByZone[index]);
-      setSelectedZones(selectedZones);
-    },
-    customTableBodyFooterRender: function (opts) {
-      const footerClasses = "";
-      return (
-        <TableRow>
-          {opts.selectableRows !== "none" ? (
-            <TableCell className={footerClasses}></TableCell>
-          ) : (
-            <TableCell className={footerClasses}></TableCell>
-          )}
-          {opts.columns
-            .filter((c) => c.display != "false")
-            .map((col, index) => {
-              if (col.name == "orgUnit.name") {
-                return (
-                  <TableCell key={index} className={footerClasses} style={{ background: "#F0F0F0" }}>
-                    <b>Total : </b>
-                  </TableCell>
-                );
-              } else if (col.name.endsWith("-ratio")) {
-                const colNamePrefix = col.name.slice(0, col.name.length - 6);
-                const colCompletedIndex = opts.columns.findIndex((c) => c.name === colNamePrefix + "-completed");
-                const colExpectedIndex = opts.columns.findIndex((c) => c.name === colNamePrefix + "-expected");
+const fetchCompleteDataSetRegistrations = async (api, quarterPeriod, DataEntries, accessibleZones) => {
+  const periods = [quarterPeriod]
+    .concat(DatePeriods.split(quarterPeriod, "monthly"))
+    .concat(DatePeriods.split(quarterPeriod, "yearly"));
 
-                let totalCompleted = opts.data.reduce((accu, item) => {
-                  return accu + item.data[colCompletedIndex];
-                }, 0);
-                let totalExpected = opts.data.reduce((accu, item) => {
-                  return accu + item.data[colExpectedIndex];
-                }, 0);
-
-                let ratio = undefined;
-                if (totalExpected > 0) {
-                  ratio = (100 * (totalCompleted / totalExpected)).toFixed(2);
-                }
-
-                return (
-                  <TableCell key={index} className={footerClasses} style={{ background: "#F0F0F0" }}>
-                    <i>
-                      <CompletionInfo
-                        completed={totalCompleted}
-                        expected={totalExpected}
-                        ratio={ratio}
-                      ></CompletionInfo>
-                    </i>
-                  </TableCell>
-                );
-              } else {
-                return <TableCell key={index} className={footerClasses}></TableCell>;
-              }
-            })}
-        </TableRow>
-      );
-    },
-  };
-};
-
-const orgUnitColumns = (distinctDataEntries, filteredCompletnessInfos) => {
-  return [
-    {
-      name: "contract.orgUnit.name",
-      label: "Name",
-      options: {
-        filter: true,
-        sort: true,
-
-        customBodyRenderLite: (dataIndex) => {
-          const info = filteredCompletnessInfos[dataIndex];
-          return (
-            <span
-              title={
-                info.contract.orgUnit.ancestors
-                  .slice(1)
-                  .map((c) => c.name)
-                  .join(" > ") +
-                " " +
-                info.contract.orgUnit.id
-              }
-            >
-              {info.contract.orgUnit.name}
-            </span>
-          );
-        },
-      },
-    },
-    {
-      name: "completedDataEntries.length",
-      label: "Completed",
-      options: {
-        filter: true,
-        sort: true,
-        display: false,
-        customBodyRenderLite: (dataIndex) => {
-          const info = filteredCompletnessInfos[dataIndex];
-          return <span title={JSON.stringify(info.completedDataEntries)}>{info.completedDataEntries.length}</span>;
-        },
-      },
-    },
-    {
-      name: "completionRatio",
-      label: "Ratio",
-      options: {
-        filter: true,
-        sort: true,
-        customBodyRenderLite: (dataIndex) => {
-          const info = filteredCompletnessInfos[dataIndex];
-          if (info == undefined) {
-            return "";
-          }
-          const completed = info.expectedDataEntries.filter((e) => e.completedDataEntry).length;
-          const expected = info.expectedDataEntries.length;
-          const ratio = info.completionRatio;
-          return <CompletionInfo completed={completed} expected={expected} ratio={ratio} />;
-        },
-      },
-    },
-
-    {
-      name: "expectedDataEntries.length",
-      label: "Expected",
-      options: {
-        filter: true,
-        sort: true,
-        display: false,
-        customBodyRenderLite: (dataIndex) => {
-          const info = filteredCompletnessInfos[dataIndex];
-          return (
-            <span
-              title={info.expectedDataEntries
-                .map(
-                  (ede) =>
-                    ede.dataEntryType.name +
-                    " " +
-                    ede.period +
-                    " " +
-                    ede.dataEntryType.dataSetId +
-                    " " +
-                    (ede.completedDataEntry ? "Y" : "N"),
-                )
-                .join("\n")}
-            >
-              {info.expectedDataEntries.length}
-            </span>
-          );
-        },
-      },
-    },
-
-    ...distinctDataEntries.map((dataEntryPeriods) => {
-      const c = dataEntryPeriods[0];
-      return {
-        name: c.period + "-" + c.dataEntryType.category + "-completed",
-        label: c.dataEntryType.category + "\n" + c.period,
-        options: {
-          filter: true,
-          sort: true,
-          customBodyRenderLite: (dataIndex) => {
-            const info = filteredCompletnessInfos[dataIndex];
-            if (info == undefined) {
-              return "";
-            }
-            const ex = info[c.period + "-" + c.dataEntryType.category];
-            if (ex == undefined) {
-              return "";
-            }
-            return (
-              <div>
-                <a
-                  style={{
-                    textDecoration: "none",
-                    color: ex.completedDataEntry ? "green" : "orange",
-                  }}
-                  href={
-                    "./index.html#/dataEntry/" +
-                    info.contract.orgUnit.id +
-                    "/" +
-                    ex.period +
-                    "/" +
-                    ex.dataEntryType.code
-                  }
-                  title={ex.period}
-                >
-                  {" "}
-                  {ex.dataEntryType.name}
-                </a>
-              </div>
-            );
-          },
-        },
-      };
-    }),
-  ];
-};
-
-const zoneStatsColumns = (distinctDataEntries, statsByZone) => {
-  return [
-    {
-      name: "ancestor.name",
-      label: "Level 2 name",
-      options: {
-        filter: true,
-        sort: true,
-      },
-    },
-    {
-      name: "orgUnit.name",
-      label: "Level 3 Name",
-      options: {
-        filter: true,
-        sort: true,
-      },
-    },
-    ...distinctDataEntries.flatMap((dataEntryPeriods) => {
-      const c = dataEntryPeriods[0];
-      const completedKey = c.period + "-" + c.dataEntryType.category + "-completed";
-      const expectedKey = c.period + "-" + c.dataEntryType.category + "-expected";
-      const ratioKey = c.period + "-" + c.dataEntryType.category + "-ratio";
-      return [
-        {
-          name: completedKey,
-          label: c.dataEntryType.category + "\n" + c.period + "\ncompleted",
-          options: {
-            filter: true,
-            sort: true,
-            display: false,
-          },
-        },
-        {
-          name: expectedKey,
-          label: c.dataEntryType.category + "\n" + c.period + "\nexpected",
-          options: {
-            filter: true,
-            sort: true,
-            display: false,
-          },
-        },
-        {
-          name: ratioKey,
-          label: c.dataEntryType.category + "\n" + c.period + "\nratio",
-          options: {
-            filter: true,
-            sort: true,
-            customBodyRenderLite: (dataIndex) => {
-              const info = statsByZone[dataIndex];
-              if (info == undefined) {
-                return "";
-              }
-
-              return (
-                <CompletionInfo completed={info[completedKey]} expected={info[expectedKey]} ratio={info[ratioKey]} />
-              );
-            },
-          },
-        },
-      ];
-    }),
-  ];
-};
-
-const buildStatsByZone = (results, distinctDataEntries) => {
-  const statsByZone = [];
-  const contractsByZone = _.groupBy(results, (c) => c.contract.orgUnit.ancestors[2] ? c.contract.orgUnit.ancestors[2].id : undefined);
-  for (let contractsForZone of Object.values(contractsByZone)) {
-    const parentZone = contractsForZone[0].contract.orgUnit.ancestors[1];
-    const zone = contractsForZone[0].contract.orgUnit.ancestors[2];
-    const stats = { orgUnit: zone, ancestor: parentZone };
-
-    for (let info of contractsForZone) {
-      for (let dataEntryPeriods of distinctDataEntries) {
-        const key = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-completed";
-
-        let count = info[key];
-        let currentCount = stats[key];
-
-        if (currentCount !== undefined) {
-          stats[key] = currentCount + count;
-        } else {
-          stats[key] = count;
-        }
-
-        const keyExpected = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-expected";
-        count = info[keyExpected];
-        currentCount = stats[keyExpected];
-
-        if (currentCount !== undefined) {
-          stats[keyExpected] = currentCount + count;
-        } else {
-          stats[keyExpected] = count;
-        }
-
-        const keyRatio = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-ratio";
-        stats[keyRatio] = stats[keyExpected] ? ((stats[key] / stats[keyExpected]) * 100).toFixed(2) : undefined;
-      }
+  const dataSets = DataEntries.getAllDataEntries().flatMap((de) => {
+    if (de.dataSetId) {
+      return [de.dataSetId];
+    } else if (de.dataSetIds) {
+      return de.dataSetIds;
+    } else {
+      return [];
     }
+  });
 
-    statsByZone.push(stats);
+  let completeDataSetRegistrations = [];
+  for (let ou of accessibleZones) {
+    const ds = await api.get("completeDataSetRegistrations", {
+      orgUnit: ou.id,
+      children: true,
+      period: periods,
+      dataSet: dataSets,
+    });
+    completeDataSetRegistrations = completeDataSetRegistrations.concat(ds.completeDataSetRegistrations);
   }
-  return statsByZone;
+
+  completeDataSetRegistrations = completeDataSetRegistrations
+    .filter((c) => c)
+    .filter((c) => {
+      // handle newer dhis2 version that has the completed flag
+      if (c.hasOwnProperty("completed")) {
+        return c.completed;
+      }
+      // else keep all records
+      return true;
+    });
+
+  return completeDataSetRegistrations;
 };
 
 const CompletenessView = (props) => {
@@ -356,90 +71,18 @@ const CompletenessView = (props) => {
         contract.matchPeriod(quarterPeriod) &&
         contract.orgUnit.ancestors.some((ancestor) => accessibleOrgunitIds.has(ancestor.id)),
     );
-
-    const periods = [quarterPeriod]
-      .concat(DatePeriods.split(quarterPeriod, "monthly"))
-      .concat(DatePeriods.split(quarterPeriod, "yearly"));
-    const dataSets = DataEntries.getAllDataEntries().map((de) => de.dataSetId);
-
-    let completeDataSetRegistrations = [];
-    for (let ou of currentUser.organisationUnits) {
-      const ds = await api.get("completeDataSetRegistrations", {
-        orgUnit: ou.id,
-        children: true,
-        period: periods,
-        dataSet: dataSets,
-      });
-      completeDataSetRegistrations = completeDataSetRegistrations.concat(ds.completeDataSetRegistrations);
-    }
-
-    completeDataSetRegistrations = completeDataSetRegistrations
-      .filter((c) => c)
-      .filter((c) => {
-        // handle newer dhis2 version that has the completed flag
-        if (c.hasOwnProperty("completed")) {
-          return c.completed;
-        }
-        // else keep all records
-        return true;
-      });
-
-    const completeDataSetRegistrationsByOrgUnitId = _.groupBy(
+    const completeDataSetRegistrations = await fetchCompleteDataSetRegistrations(
+      api,
+      quarterPeriod,
+      DataEntries,
+      currentUser.organisationUnits,
+    );
+    const { distinctDataEntries, results } = toCompleteness(
+      contracts,
       completeDataSetRegistrations,
-      (cdsr) => cdsr.organisationUnit,
+      DataEntries,
+      quarterPeriod,
     );
-    const results = [];
-    for (let contract of contracts) {
-      const expectedDataEntries = DataEntries.getExpectedDataEntries(contract, quarterPeriod);
-      if (expectedDataEntries.length > 0) {
-        const completedDataEntries = completeDataSetRegistrationsByOrgUnitId[contract.orgUnit.id] || [];
-
-        if (completedDataEntries.length > 0) {
-          for (let expectedDataEntry of expectedDataEntries) {
-            expectedDataEntry.completedDataEntry = completedDataEntries.find(
-              (c) => c.dataSet == expectedDataEntry.dataEntryType.dataSetId && c.period == expectedDataEntry.period,
-            );
-          }
-        }
-        results.push({
-          contract,
-          expectedDataEntries,
-          completedDataEntries,
-          completionRatio:
-            expectedDataEntries.length > 0
-              ? ((completedDataEntries.length / expectedDataEntries.length) * 100).toFixed(2)
-              : undefined,
-        });
-      }
-    }
-
-    const dataentries = _.groupBy(
-      results.flatMap((r) => r.expectedDataEntries),
-      (r) => (r.dataEntryType.category || r.dataEntryType.name) + "-" + r.period,
-    );
-    const distinctDataEntries = Object.values(dataentries);
-    for (let info of results) {
-      for (let dataEntryPeriods of distinctDataEntries) {
-        for (let dataEntryPeriod of dataEntryPeriods) {
-          if (dataEntryPeriod.dataEntryType.category == undefined) {
-            dataEntryPeriod.dataEntryType.category = dataEntryPeriod.dataEntryType.name;
-          }
-        }
-        const ex = info.expectedDataEntries.find((ex) =>
-          dataEntryPeriods.some((ex3) => ex.dataEntryType.code == ex3.dataEntryType.code && ex.period == ex3.period),
-        );
-
-        info[dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category] = ex;
-
-        info[dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-completed"] = ex
-          ? ex.completedDataEntry
-            ? 1
-            : 0
-          : 0;
-
-        info[dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-expected"] = ex ? 1 : 0;
-      }
-    }
     setDistinctDataEntries(distinctDataEntries);
 
     const statsByZone = buildStatsByZone(results, distinctDataEntries);
@@ -467,16 +110,16 @@ const CompletenessView = (props) => {
   return (
     <div>
       <PortalHeader>
-        <div style={{ display: "flex", flexDirection: "row", alignContent: "center", justifyContent: "flex-start"  }}>
+        <div style={{ display: "flex", flexDirection: "row", alignContent: "center", justifyContent: "flex-start" }}>
           <Typography variant="h6" style={{ marginRight: "20px" }}>
             Completeness for datasets{" "}
           </Typography>
-          <div style={{ background: "rgba(255, 255, 255, 0.20)", color: "#fff; important!",  padding:"5px" }}>
+          <div style={{ background: "rgba(255, 255, 255, 0.20)", color: "#fff; important!", padding: "5px" }}>
             <PeriodPicker
               variant="white"
               disableInputLabel={true}
               period={quarterPeriod}
-              periodDelta = {{
+              periodDelta={{
                 before: 5,
                 after: 5,
               }}

--- a/src/components/completeness/CompletenessView.js
+++ b/src/components/completeness/CompletenessView.js
@@ -76,12 +76,13 @@ const CompletenessView = (props) => {
       quarterPeriod,
       DataEntries,
       currentUser.organisationUnits,
-    );
+    );    
     const { distinctDataEntries, results } = toCompleteness(
       contracts,
       completeDataSetRegistrations,
       DataEntries,
       quarterPeriod,
+      window.location.href.split("#")[0]
     );
     setDistinctDataEntries(distinctDataEntries);
 

--- a/src/components/completeness/CompletionInfo.js
+++ b/src/components/completeness/CompletionInfo.js
@@ -8,7 +8,13 @@ function getColor(value) {
 }
 
 const CompletionInfo = ({ ratio, completed, expected }) => {
+
+  if (expected == 0) {
+    return <></>
+  }
+
   const color = getColor(ratio);
+
   return (
     <span style={{ color: color }}>
       <b title="completion ratio = completed / expected">{ratio}</b> %<br></br>

--- a/src/components/completeness/calculations.js
+++ b/src/components/completeness/calculations.js
@@ -1,46 +1,3 @@
-export const buildStatsByZone = (results, distinctDataEntries) => {
-  const statsByZone = [];
-  const contractsByZone = _.groupBy(results, (c) =>
-    c.contract.orgUnit.ancestors[2] ? c.contract.orgUnit.ancestors[2].id : undefined,
-  );
-  for (let contractsForZone of Object.values(contractsByZone)) {
-    const parentZone = contractsForZone[0].contract.orgUnit.ancestors[1];
-    const zone = contractsForZone[0].contract.orgUnit.ancestors[2];
-    const stats = { orgUnit: zone, ancestor: parentZone };
-
-    for (let info of contractsForZone) {
-      for (let dataEntryPeriods of distinctDataEntries) {
-        const key = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-completed";
-
-        let count = info[key];
-        let currentCount = stats[key];
-
-        if (currentCount !== undefined) {
-          stats[key] = currentCount + count;
-        } else {
-          stats[key] = count;
-        }
-
-        const keyExpected = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-expected";
-        count = info[keyExpected];
-        currentCount = stats[keyExpected];
-
-        if (currentCount !== undefined) {
-          stats[keyExpected] = currentCount + count;
-        } else {
-          stats[keyExpected] = count;
-        }
-
-        const keyRatio = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-ratio";
-        stats[keyRatio] = stats[keyExpected] ? ((stats[key] / stats[keyExpected]) * 100).toFixed(2) : undefined;
-      }
-    }
-
-    statsByZone.push(stats);
-  }
-  return statsByZone;
-};
-
 export const toCompleteness = (contracts, completeDataSetRegistrations, DataEntries, quarterPeriod) => {
   const completeDataSetRegistrationsByOrgUnitId = _.groupBy(
     completeDataSetRegistrations,
@@ -113,4 +70,47 @@ export const toCompleteness = (contracts, completeDataSetRegistrations, DataEntr
     }
   }
   return { distinctDataEntries, results };
+};
+
+export const buildStatsByZone = (results, distinctDataEntries) => {
+  const statsByZone = [];
+  const contractsByZone = _.groupBy(results, (c) =>
+    c.contract.orgUnit.ancestors[2] ? c.contract.orgUnit.ancestors[2].id : undefined,
+  );
+  for (let contractsForZone of Object.values(contractsByZone)) {
+    const parentZone = contractsForZone[0].contract.orgUnit.ancestors[1];
+    const zone = contractsForZone[0].contract.orgUnit.ancestors[2];
+    const stats = { orgUnit: zone, ancestor: parentZone };
+
+    for (let info of contractsForZone) {
+      for (let dataEntryPeriods of distinctDataEntries) {
+        const key = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-completed";
+
+        let count = info[key];
+        let currentCount = stats[key];
+
+        if (currentCount !== undefined) {
+          stats[key] = currentCount + count;
+        } else {
+          stats[key] = count;
+        }
+
+        const keyExpected = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-expected";
+        count = info[keyExpected];
+        currentCount = stats[keyExpected];
+
+        if (currentCount !== undefined) {
+          stats[keyExpected] = currentCount + count;
+        } else {
+          stats[keyExpected] = count;
+        }
+
+        const keyRatio = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-ratio";
+        stats[keyRatio] = stats[keyExpected] ? ((stats[key] / stats[keyExpected]) * 100).toFixed(2) : undefined;
+      }
+    }
+
+    statsByZone.push(stats);
+  }
+  return statsByZone;
 };

--- a/src/components/completeness/calculations.js
+++ b/src/components/completeness/calculations.js
@@ -1,0 +1,116 @@
+export const buildStatsByZone = (results, distinctDataEntries) => {
+  const statsByZone = [];
+  const contractsByZone = _.groupBy(results, (c) =>
+    c.contract.orgUnit.ancestors[2] ? c.contract.orgUnit.ancestors[2].id : undefined,
+  );
+  for (let contractsForZone of Object.values(contractsByZone)) {
+    const parentZone = contractsForZone[0].contract.orgUnit.ancestors[1];
+    const zone = contractsForZone[0].contract.orgUnit.ancestors[2];
+    const stats = { orgUnit: zone, ancestor: parentZone };
+
+    for (let info of contractsForZone) {
+      for (let dataEntryPeriods of distinctDataEntries) {
+        const key = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-completed";
+
+        let count = info[key];
+        let currentCount = stats[key];
+
+        if (currentCount !== undefined) {
+          stats[key] = currentCount + count;
+        } else {
+          stats[key] = count;
+        }
+
+        const keyExpected = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-expected";
+        count = info[keyExpected];
+        currentCount = stats[keyExpected];
+
+        if (currentCount !== undefined) {
+          stats[keyExpected] = currentCount + count;
+        } else {
+          stats[keyExpected] = count;
+        }
+
+        const keyRatio = dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-ratio";
+        stats[keyRatio] = stats[keyExpected] ? ((stats[key] / stats[keyExpected]) * 100).toFixed(2) : undefined;
+      }
+    }
+
+    statsByZone.push(stats);
+  }
+  return statsByZone;
+};
+
+export const toCompleteness = (contracts, completeDataSetRegistrations, DataEntries, quarterPeriod) => {
+  const completeDataSetRegistrationsByOrgUnitId = _.groupBy(
+    completeDataSetRegistrations,
+    (cdsr) => cdsr.organisationUnit,
+  );
+  const results = [];
+  for (let contract of contracts) {
+    const expectedDataEntries = DataEntries.getExpectedDataEntries(contract, quarterPeriod);
+    if (expectedDataEntries.length > 0) {
+      const completedDataEntries = completeDataSetRegistrationsByOrgUnitId[contract.orgUnit.id] || [];
+
+      if (completedDataEntries.length > 0) {
+        for (let expectedDataEntry of expectedDataEntries) {
+          if (expectedDataEntry.dataEntryType.dataSetId) {
+            expectedDataEntry.completedDataEntries = completedDataEntries.filter(
+              (c) => c.dataSet == expectedDataEntry.dataEntryType.dataSetId && c.period == expectedDataEntry.period,
+            );
+            expectedDataEntry.completed = expectedDataEntry.completedDataEntries.length > 0 ? 1 : 0;
+          } else if (expectedDataEntry.dataEntryType.dataSetIds) {
+            expectedDataEntry.completedDataEntries = completedDataEntries.filter(
+              (c) =>
+                expectedDataEntry.dataEntryType.dataSetIds.includes(c.dataSet) && c.period == expectedDataEntry.period,
+            );
+            expectedDataEntry.completed =
+              expectedDataEntry.completedDataEntries.length == expectedDataEntry.dataEntryType.dataSetIds.length
+                ? 1
+                : 0;
+          }
+        }
+      }
+
+      const completedCount = expectedDataEntries.filter((c) => c.completed).length;
+      results.push({
+        contract,
+        expectedDataEntries,
+        completedDataEntries,
+        completedCount: completedCount,
+        expectedCount: expectedDataEntries.length,
+        completionRatio:
+          expectedDataEntries.length > 0 ? ((completedCount / expectedDataEntries.length) * 100).toFixed(2) : undefined,
+      });
+    }
+  }
+
+  const dataentries = _.groupBy(
+    results.flatMap((r) => r.expectedDataEntries),
+    (r) => (r.dataEntryType.category || r.dataEntryType.name) + "-" + r.period,
+  );
+  const distinctDataEntries = Object.values(dataentries);
+  for (let info of results) {
+    for (let dataEntryPeriods of distinctDataEntries) {
+      for (let dataEntryPeriod of dataEntryPeriods) {
+        if (dataEntryPeriod.dataEntryType.category == undefined) {
+          dataEntryPeriod.dataEntryType.category = dataEntryPeriod.dataEntryType.name;
+        }
+      }
+      const ex = info.expectedDataEntries.find((ex) =>
+        dataEntryPeriods.some((ex3) => ex.dataEntryType.code == ex3.dataEntryType.code && ex.period == ex3.period),
+      );
+
+      info[dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category] = ex;
+
+      info[dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-completed"] = ex
+        ? ex.completed
+          ? 1
+          : 0
+        : 0;
+
+      info[dataEntryPeriods[0].period + "-" + dataEntryPeriods[0].dataEntryType.category + "-expected"] = ex ? 1 : 0;
+    }
+  }
+  return { distinctDataEntries, results };
+};

--- a/src/components/completeness/tables.js
+++ b/src/components/completeness/tables.js
@@ -3,7 +3,6 @@ import { TableCell, TableRow } from "@material-ui/core";
 
 import CompletionInfo from "./CompletionInfo";
 
-
 export const tableOptions = (quarterPeriod) => {
   return {
     enableNestedDataAccess: ".",
@@ -11,7 +10,7 @@ export const tableOptions = (quarterPeriod) => {
     rowsPerPage: 50,
     rowsPerPageOptions: [1, 5, 10, 20, 50, 100, 1000],
     downloadOptions: {
-      filename: "orgunit-completeness-" + quarterPeriod,
+      filename: "orgunit-completeness-" + quarterPeriod+".csv",
       separator: ",",
     },
   };
@@ -24,7 +23,7 @@ export const statsTableOptions = (quarterPeriod, statsByZone, setSelectedZones) 
     rowsPerPage: 5,
     rowsPerPageOptions: [1, 5, 10, 20, 50, 100, 1000],
     downloadOptions: {
-      filename: "zone-completeness-" + quarterPeriod,
+      filename: "zone-completeness-" + quarterPeriod+".csv",
       separator: ",",
     },
     onRowSelectionChange: (_currentRowsSelected, _allRowsSelected, rowsSelected) => {
@@ -92,6 +91,42 @@ export const orgUnitColumns = (distinctDataEntries, filteredCompletnessInfos) =>
     {
       name: "contract.orgUnit.id",
       label: "id",
+      options: {
+        filter: true,
+        sort: true,
+        display: false,
+      },
+    },
+    {
+      name: "orgUnitLevel1.name",
+      label: "Level 1",
+      options: {
+        filter: true,
+        sort: true,
+        display: false,
+      },
+    },
+    {
+      name: "orgUnitLevel2.name",
+      label: "Level 2",
+      options: {
+        filter: true,
+        sort: true,
+        display: false,
+      },
+    },
+    {
+      name: "orgUnitLevel3.name",
+      label: "Level 3",
+      options: {
+        filter: true,
+        sort: true,
+        display: false,
+      },
+    },
+    {
+      name: "orgUnitLevel4.name",
+      label: "Level 4",
       options: {
         filter: true,
         sort: true,
@@ -188,63 +223,92 @@ export const orgUnitColumns = (distinctDataEntries, filteredCompletnessInfos) =>
       },
     },
 
-    ...distinctDataEntries.map((dataEntryPeriods) => {
+    ...distinctDataEntries.flatMap((dataEntryPeriods) => {
       const c = dataEntryPeriods[0];
-      return {
-        name: c.period + "-" + c.dataEntryType.category + "-completed",
-        label: c.dataEntryType.category + "\n" + c.period,
-        options: {
-          filter: true,
-          sort: true,
-          customBodyRenderLite: (dataIndex) => {
-            const info = filteredCompletnessInfos[dataIndex];
-            if (info == undefined) {
-              return "";
-            }
-            const ex = info[c.period + "-" + c.dataEntryType.category];
-            if (ex == undefined) {
-              return "";
-            }
-            let details = undefined;
-            if (ex && ex.dataEntryType.dataSetIds) {
-              details = (
-                <span>
-                  {ex.completedDataEntries ? ex.completedDataEntries.length : 0}/{ex.dataEntryType.dataSetIds.length}
-                </span>
-              );
-            }
-            return (
-              <div>
-                <a
-                  style={{
-                    textDecoration: "none",
-                    color: ex.completed ? "green" : "orange",
-                  }}
-                  href={
-                    "./index.html#/dataEntry/" +
-                    info.contract.orgUnit.id +
-                    "/" +
-                    ex.period +
-                    "/" +
-                    ex.dataEntryType.code
-                  }
-                  title={ex.period}
-                >
-                  {" "}
-                  {ex.dataEntryType.name}
-                </a>
+      return [
+        {
+          name: c.period + "-" + c.dataEntryType.category + "-completed",
+          label: c.dataEntryType.category + "\n" + c.period,
+          options: {
+            filter: true,
+            sort: true,
+            customBodyRenderLite: (dataIndex) => {
+              const info = filteredCompletnessInfos[dataIndex];
+              if (info == undefined) {
+                return "";
+              }
+              const ex = info[c.period + "-" + c.dataEntryType.category];
+              if (ex == undefined) {
+                return "";
+              }
+              let details = undefined;
+              if (ex && ex.dataEntryType.dataSetIds) {
+                details = (
+                  <span>
+                    {ex.completedDataEntries ? ex.completedDataEntries.length : 0}/{ex.dataEntryType.dataSetIds.length}
+                  </span>
+                );
+              }
+              return (
+                <div>
+                  <a
+                    style={{
+                      textDecoration: "none",
+                      color: ex.completed ? "green" : "orange",
+                    }}
+                    href={
+                      "./index.html#/dataEntry/" +
+                      info.contract.orgUnit.id +
+                      "/" +
+                      ex.period +
+                      "/" +
+                      ex.dataEntryType.code
+                    }
+                    title={ex.period}
+                  >
+                    {" "}
+                    {ex.dataEntryType.name}
+                  </a>
 
-                {details && (
-                  <>
-                    <br></br>
-                    {details}
-                  </>
-                )}
-              </div>
-            );
+                  {details && (
+                    <>
+                      <br></br>
+                      {details}
+                    </>
+                  )}
+                </div>
+              );
+            },
           },
         },
-      };
+        {
+          name: c.period + "-" + c.dataEntryType.category + "-users",
+          label: c.dataEntryType.category +" User "+ "\n" + c.period,
+          options: {
+            filter: true,
+            sort: true,
+            display: false,
+          },
+        },
+        {
+          name: c.period + "-" + c.dataEntryType.category + "-dates",
+          label: c.dataEntryType.category +" Date "+ "\n" + c.period,
+          options: {
+            filter: true,
+            sort: true,
+            display: false,
+          },
+        },
+        {
+          name: c.period + "-" + c.dataEntryType.category + "-link",
+          label: c.dataEntryType.category +" Link "+ "\n" + c.period,
+          options: {
+            filter: true,
+            sort: true,
+            display: false,
+          },
+        },
+      ];
     }),
   ];
 };

--- a/src/components/completeness/tables.js
+++ b/src/components/completeness/tables.js
@@ -1,0 +1,315 @@
+import React, { useEffect } from "react";
+import { TableCell, TableRow } from "@material-ui/core";
+
+import CompletionInfo from "./CompletionInfo";
+
+
+export const tableOptions = (quarterPeriod) => {
+  return {
+    enableNestedDataAccess: ".",
+    print: false,
+    rowsPerPage: 50,
+    rowsPerPageOptions: [1, 5, 10, 20, 50, 100, 1000],
+    downloadOptions: {
+      filename: "orgunit-completeness-" + quarterPeriod,
+      separator: ",",
+    },
+  };
+};
+
+export const statsTableOptions = (quarterPeriod, statsByZone, setSelectedZones) => {
+  return {
+    enableNestedDataAccess: ".",
+    print: false,
+    rowsPerPage: 5,
+    rowsPerPageOptions: [1, 5, 10, 20, 50, 100, 1000],
+    downloadOptions: {
+      filename: "zone-completeness-" + quarterPeriod,
+      separator: ",",
+    },
+    onRowSelectionChange: (_currentRowsSelected, _allRowsSelected, rowsSelected) => {
+      const selectedZones = rowsSelected.map((index) => statsByZone[index]);
+      setSelectedZones(selectedZones);
+    },
+    customTableBodyFooterRender: function (opts) {
+      const footerClasses = "";
+      return (
+        <TableRow>
+          {opts.selectableRows !== "none" ? (
+            <TableCell className={footerClasses}></TableCell>
+          ) : (
+            <TableCell className={footerClasses}></TableCell>
+          )}
+          {opts.columns
+            .filter((c) => c.display != "false")
+            .map((col, index) => {
+              if (col.name == "orgUnit.name") {
+                return (
+                  <TableCell key={index} className={footerClasses} style={{ background: "#F0F0F0" }}>
+                    <b>Total : </b>
+                  </TableCell>
+                );
+              } else if (col.name.endsWith("-ratio")) {
+                const colNamePrefix = col.name.slice(0, col.name.length - 6);
+                const colCompletedIndex = opts.columns.findIndex((c) => c.name === colNamePrefix + "-completed");
+                const colExpectedIndex = opts.columns.findIndex((c) => c.name === colNamePrefix + "-expected");
+
+                let totalCompleted = opts.data.reduce((accu, item) => {
+                  return accu + item.data[colCompletedIndex];
+                }, 0);
+                let totalExpected = opts.data.reduce((accu, item) => {
+                  return accu + item.data[colExpectedIndex];
+                }, 0);
+
+                let ratio = undefined;
+                if (totalExpected > 0) {
+                  ratio = (100 * (totalCompleted / totalExpected)).toFixed(2);
+                }
+
+                return (
+                  <TableCell key={index} className={footerClasses} style={{ background: "#F0F0F0" }}>
+                    <i>
+                      <CompletionInfo
+                        completed={totalCompleted}
+                        expected={totalExpected}
+                        ratio={ratio}
+                      ></CompletionInfo>
+                    </i>
+                  </TableCell>
+                );
+              } else {
+                return <TableCell key={index} className={footerClasses}></TableCell>;
+              }
+            })}
+        </TableRow>
+      );
+    },
+  };
+};
+
+export const orgUnitColumns = (distinctDataEntries, filteredCompletnessInfos) => {
+  return [
+    {
+      name: "contract.orgUnit.id",
+      label: "id",
+      options: {
+        filter: true,
+        sort: true,
+        display: false,
+      },
+    },
+    {
+      name: "contract.orgUnit.name",
+      label: "Name",
+      options: {
+        filter: true,
+        sort: true,
+
+        customBodyRenderLite: (dataIndex) => {
+          const info = filteredCompletnessInfos[dataIndex];
+          return (
+            <span
+              title={
+                info.contract.orgUnit.ancestors
+                  .slice(1)
+                  .map((c) => c.name)
+                  .join(" > ") +
+                " " +
+                info.contract.orgUnit.id
+              }
+            >
+              {info.contract.orgUnit.name}
+            </span>
+          );
+        },
+      },
+    },
+    {
+      name: "completedCount",
+      label: "Completed",
+      options: {
+        filter: true,
+        sort: true,
+        display: false,
+        customBodyRenderLite: (dataIndex) => {
+          const info = filteredCompletnessInfos[dataIndex];
+
+          return <span title={JSON.stringify(info.completedDataEntries)}>{info.completedCount}</span>;
+        },
+      },
+    },
+
+    {
+      name: "expectedDataEntries.length",
+      label: "Expected",
+      options: {
+        filter: true,
+        sort: true,
+        display: false,
+        customBodyRenderLite: (dataIndex) => {
+          const info = filteredCompletnessInfos[dataIndex];
+          return (
+            <span
+              title={info.expectedDataEntries
+                .map(
+                  (ede) =>
+                    ede.dataEntryType.name +
+                    " " +
+                    ede.period +
+                    " " +
+                    ede.dataEntryType.dataSetId +
+                    " " +
+                    (ede.completedDataEntry ? "Y" : "N"),
+                )
+                .join("\n")}
+            >
+              {info.expectedDataEntries.length}
+            </span>
+          );
+        },
+      },
+    },
+    {
+      name: "completionRatio",
+      label: "Ratio",
+      options: {
+        filter: true,
+        sort: true,
+        customBodyRenderLite: (dataIndex) => {
+          const info = filteredCompletnessInfos[dataIndex];
+          if (info == undefined) {
+            return "";
+          }
+          const completed = info.completedCount;
+          const expected = info.expectedCount;
+          const ratio = info.completionRatio;
+          return <CompletionInfo completed={completed} expected={expected} ratio={ratio} />;
+        },
+      },
+    },
+
+    ...distinctDataEntries.map((dataEntryPeriods) => {
+      const c = dataEntryPeriods[0];
+      return {
+        name: c.period + "-" + c.dataEntryType.category + "-completed",
+        label: c.dataEntryType.category + "\n" + c.period,
+        options: {
+          filter: true,
+          sort: true,
+          customBodyRenderLite: (dataIndex) => {
+            const info = filteredCompletnessInfos[dataIndex];
+            if (info == undefined) {
+              return "";
+            }
+            const ex = info[c.period + "-" + c.dataEntryType.category];
+            if (ex == undefined) {
+              return "";
+            }
+            let details = undefined;
+            if (ex && ex.dataEntryType.dataSetIds) {
+              details = (
+                <span>
+                  {ex.completedDataEntries ? ex.completedDataEntries.length : 0}/{ex.dataEntryType.dataSetIds.length}
+                </span>
+              );
+            }
+            return (
+              <div>
+                <a
+                  style={{
+                    textDecoration: "none",
+                    color: ex.completed ? "green" : "orange",
+                  }}
+                  href={
+                    "./index.html#/dataEntry/" +
+                    info.contract.orgUnit.id +
+                    "/" +
+                    ex.period +
+                    "/" +
+                    ex.dataEntryType.code
+                  }
+                  title={ex.period}
+                >
+                  {" "}
+                  {ex.dataEntryType.name}
+                </a>
+
+                {details && (
+                  <>
+                    <br></br>
+                    {details}
+                  </>
+                )}
+              </div>
+            );
+          },
+        },
+      };
+    }),
+  ];
+};
+
+export const zoneStatsColumns = (distinctDataEntries, statsByZone) => {
+  return [
+    {
+      name: "ancestor.name",
+      label: "Level 2 name",
+      options: {
+        filter: true,
+        sort: true,
+      },
+    },
+    {
+      name: "orgUnit.name",
+      label: "Level 3 Name",
+      options: {
+        filter: true,
+        sort: true,
+      },
+    },
+    ...distinctDataEntries.flatMap((dataEntryPeriods) => {
+      const c = dataEntryPeriods[0];
+      const completedKey = c.period + "-" + c.dataEntryType.category + "-completed";
+      const expectedKey = c.period + "-" + c.dataEntryType.category + "-expected";
+      const ratioKey = c.period + "-" + c.dataEntryType.category + "-ratio";
+      return [
+        {
+          name: completedKey,
+          label: c.dataEntryType.category + "\n" + c.period + "\ncompleted",
+          options: {
+            filter: true,
+            sort: true,
+            display: false,
+          },
+        },
+        {
+          name: expectedKey,
+          label: c.dataEntryType.category + "\n" + c.period + "\nexpected",
+          options: {
+            filter: true,
+            sort: true,
+            display: false,
+          },
+        },
+        {
+          name: ratioKey,
+          label: c.dataEntryType.category + "\n" + c.period + "\nratio",
+          options: {
+            filter: true,
+            sort: true,
+            customBodyRenderLite: (dataIndex) => {
+              const info = statsByZone[dataIndex];
+              if (info == undefined) {
+                return "";
+              }
+
+              return (
+                <CompletionInfo completed={info[completedKey]} expected={info[expectedKey]} ratio={info[ratioKey]} />
+              );
+            },
+          },
+        },
+      ];
+    }),
+  ];
+};

--- a/src/components/shared/PortalHeader.js
+++ b/src/components/shared/PortalHeader.js
@@ -5,7 +5,6 @@ import ReactDOM from "react-dom";
 class PortalHeader extends React.Component {
   constructor() {
     super();
-    debugger;
     this.portalRoot = document.getElementById("portal-header");
 
     // 1: Create a new div that wraps the component
@@ -15,7 +14,6 @@ class PortalHeader extends React.Component {
   // 2: Append the element to the DOM when it mounts
   componentDidMount = () => {
     this.portalRoot = document.getElementById("portal-header");
-    debugger;
     this.portalRoot.appendChild(this.el);
   };
   // 3: Remove the element when it unmounts
@@ -25,7 +23,6 @@ class PortalHeader extends React.Component {
   render() {
     // 4: Render the element's children in a Portal
     const { children } = this.props;
-    debugger;
     return ReactDOM.createPortal(children, this.el);
   }
 }

--- a/src/components/syncs/SyncProgramGroups.js
+++ b/src/components/syncs/SyncProgramGroups.js
@@ -1,7 +1,10 @@
 import { DatePeriods, PluginRegistry } from "@blsq/blsq-report-components";
+import { Typography } from "@material-ui/core";
 import { Button, Input, Table, TableBody, TableCell, TableHead, TableRow } from "@material-ui/core";
 import _ from "lodash";
 import React, { useEffect, useState } from "react";
+import PeriodPicker from "../shared/PeriodPicker";
+import PortalHeader from "../shared/PortalHeader";
 
 const codify = (str) => {
   if (str == undefined) {
@@ -121,8 +124,9 @@ const ContractsTable = ({ contractInfos, fixGroups }) => (
                 }}
               >
                 {Array.from(new Set(contractInfos.contractForPeriod.codes)).join(", ")} <br></br>
-                <a target="_blank" href={"./index.html#/contracts/"+contractInfos.orgUnit.id} >{contractInfos.contractForPeriod.startPeriod} - {contractInfos.contractForPeriod.endPeriod}</a>
-
+                <a target="_blank" href={"./index.html#/contracts/" + contractInfos.orgUnit.id}>
+                  {contractInfos.contractForPeriod.startPeriod} - {contractInfos.contractForPeriod.endPeriod}
+                </a>
               </div>
             )}
           </TableCell>
@@ -296,7 +300,7 @@ const distance = (contract, period) =>
   Math.min(parseInt(contract.startPeriod) - parseInt(period), parseInt(contract.endPeriod) - parseInt(period));
 
 const SyncProgramGroups = (props) => {
-  const period = props.period;
+  const period = props.match.params.period;
   const [progress, setProgress] = useState("");
   const [filter, setFilter] = useState("");
   const [contractInfos, setContractInfos] = useState([]);
@@ -372,7 +376,7 @@ const SyncProgramGroups = (props) => {
   let filteredContractInfos = contractInfos;
   if (filter != "") {
     if (filter.startsWith("ancestor:")) {
-      const ancestorName = filter.slice("ancestor:".length)
+      const ancestorName = filter.slice("ancestor:".length);
       filteredContractInfos = filteredContractInfos.filter((c) => {
         return c.orgUnit.ancestors.some((a) => a.name.includes(ancestorName));
       });
@@ -389,7 +393,27 @@ const SyncProgramGroups = (props) => {
   }
   return (
     <div>
-      <h1>Synchronize groups based on contracts</h1>
+      <PortalHeader>
+        <div style={{ display: "flex", flexDirection: "row", alignContent: "center", justifyContent: "flex-start" }}>
+          <Typography variant="h6" style={{ marginRight: "20px" }}>
+            Synchronize groups based on contracts
+          </Typography>
+          <div style={{ background: "rgba(255, 255, 255, 0.20)", color: "#fff; important!", padding: "5px" }}>
+            <PeriodPicker
+              variant="white"
+              disableInputLabel={true}
+              period={period}
+              periodDelta={{
+                before: 5,
+                after: 5,
+              }}
+              onPeriodChange={(newPeriod) => {
+                props.history.push("/sync/program-groups/" + newPeriod);
+              }}
+            ></PeriodPicker>
+          </div>
+        </div>
+      </PortalHeader>
       <ContractsStats groupStats={groupStats} groupSetIndex={groupSetIndex} />
       <ContractsResume contractInfos={filteredContractInfos} progress={progress} />
       <Input

--- a/src/components/syncs/routes.js
+++ b/src/components/syncs/routes.js
@@ -10,7 +10,7 @@ export const syncsRoutes = (props) => {
       exact
       path="/sync/datasets/:period"
       render={(routerProps) => {
-        return <SyncDataSet {...props} />;
+        return <SyncDataSet {...props} {...routerProps} />;
       }}
     />,
     <Route
@@ -18,7 +18,7 @@ export const syncsRoutes = (props) => {
       exact
       path="/sync/program-groups/:period"
       render={(routerProps) => {
-        return <SyncProgramGroups {...props} />;
+        return <SyncProgramGroups {...props} {...routerProps} />;
       }}
     />,
   ];


### PR DESCRIPTION
A data entry has a dataSetId field or dataSetIds array of string
Based on that we want to know the x datasets to be marked as complete.

The completness now show these x / dataSetIds.length as here

![image](https://user-images.githubusercontent.com/371692/120190359-caa8dd00-c218-11eb-8f74-980e1b5b8a56.png)

The data entry part had to have an optional "dataSetId", the doesn't support yet a data entry playing with multiple datasets at once.

The other screens relying on dataSetId has been also reworked like the sync dataset screen

![image](https://user-images.githubusercontent.com/371692/120190823-676b7a80-c219-11eb-96f7-8158fa659eeb.png)
