### PR TITLE
Allow mass update of contracts via import wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# @blsq/blsq-report-components@1.0.62
+ 
+ - [contracts] Allow to mass update contracts fields with the wizard
+
 # @blsq/blsq-report-components@1.0.61
 
  - [sync-dataset] Fix add missing data elements (broken since 1.0.60)

--- a/src/components/contracts/ContractService.js
+++ b/src/components/contracts/ContractService.js
@@ -124,7 +124,6 @@ class ContractService {
           name: row[nameIndex],
         });
       }
-
       return {
         event: row[indexes.event_id],
         orgUnit: row[indexes.org_unit_id],
@@ -262,7 +261,7 @@ class ContractService {
     return this.computeContracts(contracts, orgUnitId);
   }
 
-  getEvent = (contractInfo, orgUnitId) => {
+  getEvent = (contractInfo, orgUnitId, contractId) => {
     const dataValues = [];
     const ignoredFields = ["id", "orgUnit"];
 
@@ -297,6 +296,9 @@ class ContractService {
       programStage: this.program.programStages[0].id,
       dataValues,
     };
+    if (contractId) {
+      event.event = contractId
+    }
     return event;
   };
 
@@ -325,7 +327,7 @@ class ContractService {
   }
 
   async createContract(orgUnitIds, contract) {
-    const events = orgUnitIds.map((orgUnitId) => this.getEvent(contract.fieldValues, orgUnitId));
+    const events = orgUnitIds.map((orgUnitId) => this.getEvent(contract.fieldValues, orgUnitId, contract.id));
     try {
       for (const orgUnitId of orgUnitIds) {
         await this.api.post("programs/" + this.program.id + "/organisationUnits/" + orgUnitId, { id: orgUnitId });
@@ -338,7 +340,7 @@ class ContractService {
   }
 
   async createContracts(contracts) {
-    const events = contracts.map((contract) => this.getEvent(contract.fieldValues, contract.orgUnit.id));
+    const events = contracts.map((contract) => this.getEvent(contract.fieldValues, contract.orgUnit.id, contract.id));
     try {
       for (const contract of contracts) {
         const orgUnitId = contract.orgUnit.id;

--- a/src/components/contracts/wizard/Step2.js
+++ b/src/components/contracts/wizard/Step2.js
@@ -29,7 +29,7 @@ const Step2 = ({ contractsToImport, dhis2, setValidatedContracts, setIsLoading }
         };
 
         const fieldValues = {
-          id: "csv_" + (index + 1),
+          id: contractRaw.id ? contractRaw.id : undefined,
           contract_start_date: contractRaw.contract_start_date,
           contract_end_date: contractRaw.contract_end_date,
           orgUnit: orgUnit,
@@ -70,9 +70,13 @@ const Step2 = ({ contractsToImport, dhis2, setValidatedContracts, setIsLoading }
             }
           }
         });
+        const sameContractId = currentContracts.find(
+          (currentContract) => contractRaw.id && currentContract.id !== contractRaw.id
+        );        
+        contractRaw.action = sameContractId ? "update" : "create"
         // validate overlaps
         const overlappingContract = currentContracts.find(
-          (currentContract) => currentContract.orgUnit.id == contract.orgUnit.id && currentContract.overlaps(contract),
+          (currentContract) => currentContract.id !== contract.id && currentContract.orgUnit.id == contract.orgUnit.id && currentContract.overlaps(contract),
         );
         if (overlappingContract) {
           contractRaw.warnings.push(
@@ -81,7 +85,7 @@ const Step2 = ({ contractsToImport, dhis2, setValidatedContracts, setIsLoading }
               " -> " +
               overlappingContract.endPeriod +
               " : " +
-              overlappingContract.codes.join(" "),
+              overlappingContract.codes.join(" ") +`(${overlappingContract.id})`,
           );
         }
 
@@ -129,7 +133,7 @@ const Step2 = ({ contractsToImport, dhis2, setValidatedContracts, setIsLoading }
         <MUIDataTable
           title={""}
           data={contracts}
-          columns={["orgUnit-id", "orgUnit-name"].concat(contractFields.map((f) => f.code)).concat(["warnings", "orgUnit-path"])}
+          columns={["id","orgUnit-id", "orgUnit-name"].concat(contractFields.map((f) => f.code)).concat(["action","warnings", "orgUnit-path"])}
           options={{
             fixedHeader: true,
             responsive: 'scrollMaxHeight',

--- a/src/components/contracts/wizard/Step3.js
+++ b/src/components/contracts/wizard/Step3.js
@@ -4,6 +4,8 @@ const Step3 = ({ validatedContracts, progress }) => (
   <div>
     <h2>Step 3 : Import summary</h2>
     Confirm the import of {validatedContracts.length} contracts. <br></br>
+    It will update {validatedContracts.filter((r) => r.action == "update").length} contracts and try to create{" "}
+    {validatedContracts.filter((r) => r.action == "create").length} contracts
     {progress}
   </div>
 );

--- a/src/components/contracts/wizard/Wizard.js
+++ b/src/components/contracts/wizard/Wizard.js
@@ -84,6 +84,10 @@ function HorizontalLabelPositionBelowStepper({ dhis2 }) {
         contractFields.forEach((field) => (fieldValues[field.code] = contractRaw[field.code]));
 
         const contract = contractService.newContract(fieldValues);
+
+        if (contractRaw.action == "update") {
+          contract.id = contractRaw.id
+        }
         return contract;
       });
 


### PR DESCRIPTION
If there's an id column filled with the event id the event will get updated with content of the csv.
the csv "export" can be used to "import" (don't put the events you don't want to touch, this might override the contract)

**procedure**
1. First filter the target contracts (eg you only want a sub region and only some contract type, active now)
2. Click on the "cloud" download button in the table
![image](https://user-images.githubusercontent.com/371692/127468996-ab1aa4b7-2a17-45fe-9bb8-63102cb33871.png)
3. Be careful with great power come great responsabilities. 
    - mass updates are not easily to undo and easy to mess up => ask a backup, keep original CSV just in case)
4. Modify the csv 
   - strip contracts you don't want to update (note that it you import them, it might overrides changes done in between your export and the import, if it took time to review the csv with clients)
   - update the one you want (eg change the equity)
 
![image](https://user-images.githubusercontent.com/371692/127469580-f55de0f3-7fbc-4e75-8f4a-8bcc5c8380f5.png)

5. Go to the import wizard #/contracts/import
6. Upload the modified csv
![image](https://user-images.githubusercontent.com/371692/127469755-83d00f8a-3bfa-4a8c-8031-de114e332e42.png)

7. Check what will be done
![image](https://user-images.githubusercontent.com/371692/127470634-4706ba6e-de18-4546-9de2-10c1d6744c55.png)

8. Confirm : wait it completes go back to the contracts page
9. Verify a few contracts
![image](https://user-images.githubusercontent.com/371692/127471219-52ade5d0-5c8f-4d3f-bc68-cd7595b4a673.png)
