### PR TITLE
fix: uses function component to enforce debounce, limiting number of …

### DIFF
--- a/src/components/dataentry/Dhis2Input.js
+++ b/src/components/dataentry/Dhis2Input.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useContext } from "react";
 import { TextField, Tooltip, ClickAwayListener } from "@material-ui/core";
 import FormDataContext from "./FormDataContext";
-import useDebounce from "./useDebounce";
+import useDebounce from "../shared/useDebounce";
 
 const Dhis2Input = ({ dataElement }) => {
   const formDataContext = useContext(FormDataContext);

--- a/src/components/invoices/InvoiceSelectionContainer.js
+++ b/src/components/invoices/InvoiceSelectionContainer.js
@@ -10,7 +10,7 @@ import PeriodPicker from "../shared/PeriodPicker";
 import searchOrgunit from "./searchOrgunit";
 import SelectionResultsContainer from "./SelectionResultsContainer";
 
-import useDebounce from "../dataentry/useDebounce";
+import useDebounce from "../shared/useDebounce";
 
 const styles = (theme) => ({
   paper: theme.mixins.gutters({

--- a/src/components/invoices/invoiceRoutes.js
+++ b/src/components/invoices/invoiceRoutes.js
@@ -1,7 +1,7 @@
 import React from "react";
 import InvoiceSelectionContainer from "./InvoiceSelectionContainer";
 import InvoicePage from "./InvoicePage";
-import { Route, Redirect } from "react-router-dom";
+import { Route } from "react-router-dom";
 import PluginRegistry from "../core/PluginRegistry";
 
 const invoiceRoutes = (props) => {
@@ -28,9 +28,7 @@ const invoiceRoutes = (props) => {
       path="/select"
       exact
       component={(routerProps) => {
-        const params = new URLSearchParams(
-          routerProps.location.search.substring(1),
-        );
+        const params = new URLSearchParams(routerProps.location.search.substring(1));
         const period = params.get("period");
         const parent = params.get("parent");
         let ouSearchValue = params.get("q");
@@ -56,15 +54,6 @@ const invoiceRoutes = (props) => {
         );
       }}
     />,
-    /*
-    TODO this break things ?
-    ,
-    <Redirect key={"redirect-invoices-to-reports"}
-      exact={true}
-      from="/invoices/:period/:orgUnitId/:invoiceCode"
-      to="/reports/:period/:orgUnitId/:invoiceCode"
-    />,
-    */
   ];
 };
 

--- a/src/components/invoices/searchOrgunit.js
+++ b/src/components/invoices/searchOrgunit.js
@@ -1,0 +1,42 @@
+import PluginRegistry from "../core/PluginRegistry";
+
+async function searchOrgunit({ searchValue, user, period, parent, contractedOrgUnitGroupId, dhis2 }) {
+  const orgUnitsResp = await dhis2.searchOrgunits(
+    searchValue,
+    user.dataViewOrganisationUnits,
+    contractedOrgUnitGroupId,
+    parent,
+  );
+  let categoryList = [];
+  if (dhis2.categoryComboId) {
+    categoryList = await this.searchCategoryCombo(searchvalue);
+    categoryList.forEach((cl) =>
+      orgUnitsResp.organisationUnits.push({
+        id: cl.id,
+        shortName: cl.shortName,
+        name: cl.name,
+        ancestors: [],
+        level: cl.level,
+        organisationUnitGroups: cl.organisationUnitGroups,
+      }),
+    );
+  }
+  const contractService = PluginRegistry.extension("contracts.service");
+  if (contractService) {
+    const contracts = await contractService.findAll();
+    const contractByOrgUnitId = {};
+    contracts.forEach((contract) => {
+      if (contractByOrgUnitId[contract.orgUnit.id] == undefined) {
+        contractByOrgUnitId[contract.orgUnit.id] = [];
+      }
+      contractByOrgUnitId[contract.orgUnit.id].push(contract);
+    });
+    orgUnitsResp.organisationUnits.forEach((orgUnit) => {
+      orgUnit.contracts = contractByOrgUnitId[orgUnit.id] || [];
+      orgUnit.activeContracts = orgUnit.contracts.filter((c) => c.matchPeriod(period));
+    });
+  }
+  return orgUnitsResp.organisationUnits;
+};
+
+export default searchOrgunit;

--- a/src/components/shared/RerenderDebug.js
+++ b/src/components/shared/RerenderDebug.js
@@ -1,0 +1,12 @@
+import React, { useState, useEffect } from "react";
+ 
+const RerenderDebug = () => {
+ const [color, setColor] = useState("#000");
+ 
+ useEffect(() => {
+   setColor("#" + (((1 << 24) * Math.random()) | 0).toString(16));
+ }, []);
+  return <span style={{ background: color }}>{color}</span>;
+};
+ 
+export default RerenderDebug;

--- a/src/components/shared/useDebounce.js
+++ b/src/components/shared/useDebounce.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from "react";
+import { useCallback, useState } from "react";
 import _ from "lodash";
 
 const useDebounce = (obj, wait = 1250) => {


### PR DESCRIPTION
In this screen, typing the orgunit name trigger a lot dhis2 api calls.

![image](https://user-images.githubusercontent.com/371692/151126949-591fbe38-c559-4efa-8c4a-21fde41aedee.png)

Updating the url via the history api, triggers a re render and the components fetch again the data for each char typed.

![image](https://user-images.githubusercontent.com/371692/151126612-cd4294cb-631c-482f-83fe-a598eedc4ea5.png)

This is now partially fixed by
- debouncing the url update and query
- migrating the component to functional style (vs Component based) 

but it still issue 2 queries on history change but since it already improve a lots
