### PR TITLE
fix : rollup external lib warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,6 +18,12 @@ export default {
     }
   ],
   external: [
+      ...Object.keys(pkg.dependencies || {}),
+      ...Object.keys(pkg.peerDependencies || {}),
+      "i18next",
+      "papaparse",
+      "mui-datatables",
+      "recharts",
     /^@babel.*/,
     /^@date-io\/.*/,
     /^@material-ui\/.*/,
@@ -25,6 +31,7 @@ export default {
     "classnames",
     "clsx",
     "d2",
+    "d2/lib/d2",
     "history",
     /^lodash.*/,
     "moment",

--- a/src/components/invoices/searchOrgunit.js
+++ b/src/components/invoices/searchOrgunit.js
@@ -1,5 +1,22 @@
 import PluginRegistry from "../core/PluginRegistry";
 
+async function searchCategoryCombo({ searchValue, contractedOrgUnitGroupId, dhis2 }) {
+  const categoryCombos = await dhis2.getCategoryComboById();
+  let optionsCombos = categoryCombos.categoryOptionCombos.filter(
+    (cc) => cc.name.toLowerCase().indexOf(searchValue.toLowerCase()) > -1,
+  );
+  return optionsCombos.map((option) => {
+    return {
+      id: option.id,
+      shortName: option.shortName,
+      name: option.name,
+      ancestors: [],
+      level: 0,
+      organisationUnitGroups: [{ name: "", id: contractedOrgUnitGroupId }],
+    };
+  });
+}
+
 async function searchOrgunit({ searchValue, user, period, parent, contractedOrgUnitGroupId, dhis2 }) {
   const orgUnitsResp = await dhis2.searchOrgunits(
     searchValue,
@@ -9,7 +26,7 @@ async function searchOrgunit({ searchValue, user, period, parent, contractedOrgU
   );
   let categoryList = [];
   if (dhis2.categoryComboId) {
-    categoryList = await this.searchCategoryCombo(searchvalue);
+    categoryList = await searchCategoryCombo({ searchValue, contractedOrgUnitGroupId, dhis2 });
     categoryList.forEach((cl) =>
       orgUnitsResp.organisationUnits.push({
         id: cl.id,
@@ -37,6 +54,6 @@ async function searchOrgunit({ searchValue, user, period, parent, contractedOrgU
     });
   }
   return orgUnitsResp.organisationUnits;
-};
+}
 
 export default searchOrgunit;


### PR DESCRIPTION
before : `yarn build`

```
(!) Unresolved dependencies
https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
d2/lib/d2 (imported by src/support/Dhis2.js)
notistack (imported by src/components/App.js, src/components/shared/snackBars/SnackBarContainer.js)
i18next (imported by src/support/configureI18N.js)
qs (imported by src/components/contracts/utils/index.js, src/components/contracts/utils/filtersUtils.js)
papaparse (imported by src/components/dataentry/CodeGenerator.js, src/components/dataentry/DecisionTable.js, src/components/contracts/wizard/Step1.js)
mui-datatables (imported by src/components/shared/Table.js, src/components/contracts/wizard/Step2.js, src/components/completeness/CompletenessView.js)
recharts (imported by src/components/contracts/ContractsPeriodStats.js)
```
after : the warning is gone.

todo :
 - [x] now need to test the impact on the report apps (config-overrides.js ?)