### PR TITLE
fix: reverses dates in period picker to try to improve UX

### DIFF
--- a/src/components/contracts/PeriodPicker.js
+++ b/src/components/contracts/PeriodPicker.js
@@ -37,6 +37,7 @@ const PeriodPicker = ({ currentPeriod, mode, fieldName, min, max, onPeriodChange
     year = year + 1;
   }
   const visibleMonths = visibibleQuarters
+    .reverse()
     .map((period) => {
       const monthPeriod = DatePeriods.split(period, "monthly")[indexOfMonth];
       return {


### PR DESCRIPTION
This PR prevents the date picker from starting at the minimum possible year, 1975.

https://user-images.githubusercontent.com/13802104/152797252-fc4ce2d5-52a3-40ab-b65c-c26455629c00.mp4


