### PR TITLE
feat: filters orgunits during contract creation according to user access

### DIFF
--- a/src/components/shared/OuSearch.js
+++ b/src/components/shared/OuSearch.js
@@ -75,7 +75,7 @@ const OuSearch = ({ t, orgUnit, onChange, label, defaultValue }) => {
     setIsLoading(true);
     const orgUnitsResp = await dhis2.searchOrgunits(
       searchValue,
-      currentUser,
+      currentUser.organisationUnits,
       null,
       null,
       maxResult,


### PR DESCRIPTION
This PR would ensure that users can only search for the orgunits to which they have access during contract creation. It passes in the the user's orgunits to the filtering mechanism.