### PR TITLE
Improve validations and contract import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# @blsq/blsq-report-components@1.0.86
+
+- [contracts] Allow validator to access all other contracts for cross validations.
+- [contracts] Import omit blanks in csv and turn them as undefined.
+
 # @blsq/blsq-report-components@1.0.85
 
 - [contracts] Reminds users to sync datasets, groups after successful contract creation

--- a/src/components/contracts/ContractService.js
+++ b/src/components/contracts/ContractService.js
@@ -141,12 +141,12 @@ class ContractService {
     return contracts;
   }
 
-  validateContract(contract) {
+  validateContract(contract, contracts) {
     const i18n = PluginRegistry.extension("core.i18n");
     const t = (key, options) => i18n.translator.translate(key, options);
     const validators = this.getValidators();
     const contractFields = this.toContractFields(this.program);
-    return this._validate(validators, contract, { contractFields, t });
+    return this._validate(validators, contract, { contractFields, t, contracts });
   }
 
   getValidators() {

--- a/src/components/contracts/ContractsDialog.js
+++ b/src/components/contracts/ContractsDialog.js
@@ -77,7 +77,7 @@ const ContractsDialog = ({
 
   useEffect(() => {
     const newCurrentContract = contract.id ? contract : currentContract;
-    const errors = contractService.validateContract(newCurrentContract);
+    const errors = contractService.validateContract(newCurrentContract, contracts);
 
     setCurrentContract(newCurrentContract);
     setValidationErrors(errors);
@@ -111,7 +111,7 @@ const ContractsDialog = ({
     updatedContract.startPeriod = toMonthlyPeriod(updatedContract.fieldValues.contract_start_date);
     updatedContract.endPeriod = toMonthlyPeriod(updatedContract.fieldValues.contract_end_date);
 
-    const errors = contractService.validateContract(updatedContract);
+    const errors = contractService.validateContract(updatedContract, contracts);
 
     setCurrentContract({
       ...updatedContract,

--- a/src/components/contracts/wizard/Step1.js
+++ b/src/components/contracts/wizard/Step1.js
@@ -8,6 +8,14 @@ function isFunction(functionToCheck) {
   return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
  }
 
+
+ function parseDynamicReturningUndefined(value, field) {
+   if (value == '') { 
+      return undefined
+   }
+   return value.trim()
+ }
+
 const Step1 = ({ contractsToImport, setContractsToImport }) => {
   const contractService = PluginRegistry.extension("contracts.service");
 
@@ -18,6 +26,7 @@ const Step1 = ({ contractsToImport, setContractsToImport }) => {
 
     PapaParse.parse(file, {
       header: true,
+      transform: parseDynamicReturningUndefined,
       complete: function (data) {
         const contractService = PluginRegistry.extension("contracts.service");
         const contractFields = contractService.contractFields();

--- a/src/components/contracts/wizard/Step2.js
+++ b/src/components/contracts/wizard/Step2.js
@@ -94,9 +94,9 @@ const Step2 = ({ contractsToImport, dhis2, setValidatedContracts, setIsLoading }
               contractRaw.warnings.push(
                 "invalid value for " +
                   field.code +
-                  " " +
+                  " '" +
                   fieldValue +
-                  " unknown : " +
+                  "' unknown : " +
                   field.optionSet.options.map((o) => o.code).join(" , "),
               );
             }


### PR DESCRIPTION
on Cameroon migration, 
- we wanted to be able to cross validate main orgunit's contract and the subcontracted info.
- the csv was holding empty string that were validated against optionSets possible values.