### PR TITLE
Fix: Check also if there is a data entry linked to the org unit

### DIFF
--- a/src/components/invoices/SelectionResultsContainer.js
+++ b/src/components/invoices/SelectionResultsContainer.js
@@ -30,13 +30,17 @@ const contractsToTooltip = (orgUnit, period) => {
 const SelectionResultsContainer = (props) => {
   const { classes, t, orgUnits, levels, period, pager } = props;
   const invoices = PluginRegistry.extension("invoices.invoices");
+  const dataEntries = PluginRegistry.extension("dataentry.dataEntries");
   const filteredOrgunits = [];
   const omitedOrgunits = [];
 
   if (orgUnits)
     for (let ou of orgUnits) {
       const codes = invoices.getInvoiceTypeCodes(ou, period);
-      if (codes && codes.length > 0) {
+      const activeContract = ou.activeContracts && ou.activeContracts[0];
+      const dataEntryCodes = activeContract ? dataEntries.getExpectedDataEntries(activeContract, period) : [];
+
+      if ((codes && codes.length > 0) || dataEntryCodes.length > 0) {
         filteredOrgunits.push(ou);
       } else {
         omitedOrgunits.push(ou);
@@ -48,7 +52,7 @@ const SelectionResultsContainer = (props) => {
       {orgUnits && pager && pager.nextPage && <b style={{ color: "darkblue" }}>{t("invoices.refineYourQuery")}</b>}
       {orgUnits && (
         <span
-          style={{ float: "right", color:"grey" }}
+          style={{ float: "right", color: "grey" }}
           title={omitedOrgunits
             .slice(0, 20)
             .map((o) => o.name)

--- a/src/components/invoices/SelectionResultsContainer.js
+++ b/src/components/invoices/SelectionResultsContainer.js
@@ -30,16 +30,17 @@ const contractsToTooltip = (orgUnit, period) => {
 const SelectionResultsContainer = (props) => {
   const { classes, t, orgUnits, levels, period, pager } = props;
   const invoices = PluginRegistry.extension("invoices.invoices");
-  const dataEntries = PluginRegistry.extension("dataentry.dataEntries");
   const filteredOrgunits = [];
   const omitedOrgunits = [];
 
   if (orgUnits)
     for (let ou of orgUnits) {
       const codes = invoices.getInvoiceTypeCodes(ou, period);
-      const activeContract = ou.activeContracts && ou.activeContracts[0];
+      // WARN if you modify this code check a project (ex ethiopia) that don't have contracts or no data entry
+      const activeContract = ou.activeContracts && ou.activeContracts[0];     
+      const dataEntries = PluginRegistry.extension("dataentry.dataEntries");
       const dataEntryCodes = activeContract ? dataEntries.getExpectedDataEntries(activeContract, period) : [];
-
+      // display the orgunit if some invoices or if some data entry (note having a data entry, doesn't imply having invoices, (ex burundi))
       if ((codes && codes.length > 0) || dataEntryCodes.length > 0) {
         filteredOrgunits.push(ou);
       } else {


### PR DESCRIPTION
For some org unit types on Burundi case, we can entry the data but the invoice is generated at their parents level(consolidated invoice). Especially for the regulators.  So if those org units are omitted in search result, no way to enter their data. 