### PR TITLE
Prevent focus on tab for dhis2 formula

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# @blsq/blsq-report-components@1.0.89
+
+- [dataentry] Prevent Dhis2Formula to have the tab focus
 
 # @blsq/blsq-report-components@1.0.88
 

--- a/src/components/dataentry/Dhis2Formula.js
+++ b/src/components/dataentry/Dhis2Formula.js
@@ -77,6 +77,7 @@ const Dhis2Formula = ({ formula }) => {
             type="text"
             value={rawValue || ""}
             inputProps={{
+              tabIndex: -1,
               style: {
                 textAlign: "right",
                 backgroundColor: error ? "red" : "lightgrey",


### PR DESCRIPTION
since they are readonly, we don't the dhis2 formulas (calculated fields) to have the focus when tabbing between fields.