### PR TITLE
Allow to specify another period and a specific dataset

### DIFF
--- a/src/components/completeness/calculations.js
+++ b/src/components/completeness/calculations.js
@@ -1,43 +1,74 @@
-export const toCompleteness = (contracts, completeDataSetRegistrations, DataEntries, quarterPeriod, invoiceAppUrl) => {
+import DatePeriods from "../../support/DatePeriods";
+
+export const dsRegistrationPeriods = (dataSet, period) => {
+  const periods = DatePeriods.split(period, dataSet.periodType.toLowerCase());
+  return periods;
+};
+
+export const toCompleteness = (
+  contracts,
+  completeDataSetRegistrations,
+  DataEntries,
+  quarterPeriod,
+  invoiceAppUrl,
+  dataSets,
+) => {
   const completeDataSetRegistrationsByOrgUnitId = _.groupBy(
     completeDataSetRegistrations,
     (cdsr) => cdsr.organisationUnit,
   );
+  const dataSetsById = _.keyBy(dataSets, (dataSet) => dataSet.id);
   const results = [];
   for (let contract of contracts) {
     const expectedDataEntries = DataEntries.getExpectedDataEntries(contract, quarterPeriod);
     if (expectedDataEntries.length > 0) {
       const completedDataEntries = completeDataSetRegistrationsByOrgUnitId[contract.orgUnit.id] || [];
 
-      if (completedDataEntries.length > 0) {
-        for (let expectedDataEntry of expectedDataEntries) {
-          if (expectedDataEntry.dataEntryType.dataSetId) {
-            expectedDataEntry.completedDataEntries = completedDataEntries.filter(
-              (c) => c.dataSet == expectedDataEntry.dataEntryType.dataSetId && c.period == expectedDataEntry.period,
-            );
-            expectedDataEntry.completed = expectedDataEntry.completedDataEntries.length > 0 ? 1 : 0;
-          } else if (expectedDataEntry.dataEntryType.dataSetIds) {
-            expectedDataEntry.completedDataEntries = completedDataEntries.filter(
-              (c) =>
-                expectedDataEntry.dataEntryType.dataSetIds.includes(c.dataSet) && c.period == expectedDataEntry.period,
-            );
-            expectedDataEntry.completed =
-              expectedDataEntry.completedDataEntries.length == expectedDataEntry.dataEntryType.dataSetIds.length
-                ? 1
-                : 0;
+      for (let expectedDataEntry of expectedDataEntries) {
+        const expectedDataSets = expectedDataEntry.dataEntryType.dataSetId
+          ? [expectedDataEntry.dataEntryType.dataSetId]
+          : expectedDataEntry.dataEntryType.dataSetIds;
+
+        if (contract.orgUnit.id =="S35ZacR66kX") {
+          debugger;
+        }
+        const expectedCount = 0;
+        const completedCount = 0;
+        expectedDataEntry.completedDataEntries = [];
+        for (const expectedDataSetId of expectedDataSets) {
+          const dataSet = dataSetsById[expectedDataSetId];
+          const periods = dsRegistrationPeriods(dataSet, expectedDataEntry.period);
+          for (const period of periods) {
+            expectedCount += 1;
+            const completeForPeriod = completedDataEntries.filter((c) => c.dataSet == dataSet.id && c.period == period);
+            completedCount += completeForPeriod.length;
+            for (const c of completeForPeriod) {
+              expectedDataEntry.completedDataEntries.push(c);
+            }
           }
         }
+
+        expectedDataEntry.completed = expectedCount == completedCount;
+        expectedDataEntry.expectedCount = expectedCount;
+        expectedDataEntry.completedCount = completedCount;
       }
 
-      const completedCount = expectedDataEntries.filter((c) => c.completed).length;
+      const completedCount = expectedDataEntries
+        .filter((c) => c.completedCount)
+        .map((c) => c.completedCount)
+        .reduce((a, b) => a + b, 0);
+      const expectedCount = expectedDataEntries
+        .filter((c) => c.expectedCount)
+        .map((c) => c.expectedCount)
+        .reduce((a, b) => a + b, 0);
       const record = {
         contract,
         expectedDataEntries,
         completedDataEntries,
         completedCount: completedCount,
-        expectedCount: expectedDataEntries.length,
+        expectedCount: expectedCount,
         completionRatio:
-          expectedDataEntries.length > 0 ? ((completedCount / expectedDataEntries.length) * 100).toFixed(2) : undefined,
+          expectedDataEntries.length > 0 ? ((completedCount / expectedCount) * 100).toFixed(2) : undefined,
       };
 
       if (record.completionRatio) {
@@ -49,6 +80,7 @@ export const toCompleteness = (contracts, completeDataSetRegistrations, DataEntr
           record["orgUnitLevel" + index] = ancestor;
         });
       }
+
       results.push(record);
     }
   }
@@ -82,9 +114,9 @@ export const toCompleteness = (contracts, completeDataSetRegistrations, DataEntr
           ex.dataEntryType.code
         : undefined;
 
-      if (ex && ex.completed) {
-        info[prefix + "-users"] = ex.completedDataEntries.map((e) => e.storedBy).join("\n");
-        info[prefix + "-dates"] = ex.completedDataEntries.map((e) => e.date).join("\n");
+      if (ex && ex.completedDataEntries) {
+        info[prefix + "-users"] = Array.from(new Set(ex.completedDataEntries.map((e) => e.storedBy))).join("\n");
+        info[prefix + "-dates"] = Array.from(new Set(ex.completedDataEntries.map((e) => e.date))).join("\n");
       }
 
       info[prefix + "-completed"] = ex ? (ex.completed ? 1 : 0) : 0;

--- a/src/components/completeness/tables.js
+++ b/src/components/completeness/tables.js
@@ -297,9 +297,10 @@ export const orgUnitColumns = (distinctDataEntries, filteredCompletnessInfos, t)
               }
               let details = undefined;
               if (ex && ex.dataEntryType.dataSetIds) {
+                debugger
                 details = (
                   <span>
-                    {ex.completedDataEntries ? ex.completedDataEntries.length : 0}/{ex.dataEntryType.dataSetIds.length}
+                    {ex.completedDataEntries ? ex.completedCount : 0}/{ ""+ex.expectedCount}
                   </span>
                 );
               }

--- a/src/components/dataentry/CalculatorFactory.test.js
+++ b/src/components/dataentry/CalculatorFactory.test.js
@@ -18,7 +18,8 @@ describe("CalculatorFactory", () => {
                     "declaree": "roUjqa7stCo",
                     "validee": "YAMlbdR0wVt",
                     "subsides": "Ey3nvMokVVf",
-                    "prix_unitaire": "kqjh11e8gXt"
+                    "prix_unitaire": "kqjh11e8gXt",
+                    "taux_de_change" : "dksfmlekfff"
                 },
                 {
                     "name": "Nouvelle consult curative pour des pers indigents (max 5%)",
@@ -72,9 +73,15 @@ describe("CalculatorFactory", () => {
                     "description": "quarterly_subsides",
                     "expression": "sum(%{subsides_current_quarter_values})",
                     "frequency": "monthly",
+                    "exportable_formula_code": null                    
+                },
+                "taux_de_change_pays": {
+                    "short_name": "Prix unitaire",
+                    "description": "Prix unitaire prenant en compte la categorie d'équité",
+                    "expression": "taux_de_change_level_1_quarterly",
+                    "frequency": "monthly",
                     "exportable_formula_code": null
-                    
-                }
+                },
             },
             "activity_decision_tables": [
                 {
@@ -226,6 +233,7 @@ describe("CalculatorFactory", () => {
     const orgUnit = {
         id: "zaerz654",
         name: "Orgunit name",
+        path: "/bleALGLG/DFSFEZ/zaerz654",
         activeContracts: [{
             startPeriod: "2019Q1",
             endPerio: "2020Q2",
@@ -236,8 +244,8 @@ describe("CalculatorFactory", () => {
     }
 
     const defaultCoc = "defaultcocid"
-    const newDataValue = (period, de, value) => {
-        return { orgUnit: orgUnit.id, period: period, dataElement: de, value: value, categoryOptionCombo: defaultCoc }
+    const newDataValue = (period, de, value, orgUnitId) => {
+        return { orgUnit: orgUnitId || orgUnit.id, period: period, dataElement: de, value: value, categoryOptionCombo: defaultCoc }
     }
 
     it("it's calculating quantity: decision table, activity and package formulas + ROUND SUM %{_values}", () => {
@@ -414,4 +422,36 @@ describe("CalculatorFactory", () => {
         expect(calculator.quantite_pma_quant03_quarterly_subsides_zaerz654_202003()).toEqual(expectedTotal)
 
     });
+
+    it("it's calculating quantity on a quaterly period: _level_1_quarterly", () => {
+        const quantityPackage = packages.quantite_pma
+        const period = "2020Q1"
+        const rawValues = [
+            newDataValue("202001", quantityPackage.activities[0].validee, "4"),
+            newDataValue("202001", quantityPackage.activities[1].validee, "8"),
+            newDataValue("202001", quantityPackage.activities[2].validee, "10"),
+            newDataValue("202002", quantityPackage.activities[0].validee, "1"),
+            newDataValue("202003", quantityPackage.activities[1].validee, "2"),
+            newDataValue("202002", quantityPackage.activities[2].validee, "3"),
+            newDataValue("2020Q1", quantityPackage.activities[0].taux_de_change, "95","bleALGLG"),
+            
+        ]
+
+        const calculator = generateCalculator(
+            quantityPackage,
+            orgUnit.id,
+            period,
+            Object.keys(quantityPackage.activity_formulas),
+            Object.keys(quantityPackage.formulas),
+            orgUnit)
+
+        const indexedValues = _.groupBy(rawValues, (v) =>
+            [v.orgUnit, v.period, v.dataElement, v.categoryOptionCombo].join("-"),
+        );
+
+        calculator.setIndexedValues(indexedValues)
+        calculator.setDefaultCoc(defaultCoc)
+
+        expect(calculator.quantite_pma_quant01_taux_de_change_pays_zaerz654_202001()).toEqual(95)
+    });    
 })

--- a/src/components/dataentry/CodeGenerator.js
+++ b/src/components/dataentry/CodeGenerator.js
@@ -40,6 +40,33 @@ export const generateGetterSetterForState = (hesabuPackage, activity, state, org
   return codes.join("\n");
 };
 
+export const generateGetterSetterForStateQuarterly = (hesabuPackage, activity, state, orgunitid, period) => {
+  const codes = [];
+  const quarterPeriod = DatePeriods.split(period, "quarterly")[0];
+
+  const field_name = `${hesabuPackage.code}_${activity.code}_${state}_quarterly_${orgunitid}_${period}`;
+  // getter
+  codes.push(`${field_name}: function(){`);
+  codes.push("    if (calculator.indexedValues()) {");
+  codes.push('         const deCoc = "' + activity[state] + "\".split('.');");
+  codes.push(
+    `         const k = [\"${orgunitid}\", \"${quarterPeriod}\", deCoc[0], deCoc[1] || calculator.defaultCoc()].join("-");`,
+  );
+  codes.push("         const v = calculator.indexedValues()[k]");
+  codes.push('         if(v && v[0].value == "") { return 0 }');
+  codes.push("         if(v) { return parseFloat(v[0].value) }");
+  codes.push("    }");
+  codes.push(`   return calculator.field_${field_name} == undefined ? 0 : this.field_${field_name}`);
+  codes.push("},");
+
+  // setter
+  codes.push(`set_${field_name}: function(val){`);
+  codes.push(`   calculator.field_${field_name} = val`);
+  codes.push("},");
+
+  return codes.join("\n");
+};
+
 export const generateGetterSetterForStateLevel1Quarterly = (hesabuPackage, activity, state, orgUnit, period) => {
   const quarterPeriod = DatePeriods.split(period, "quarterly")[0];
   const codes = [];
@@ -108,6 +135,10 @@ export const generateActivityFormula = (
     substitutions[
       substit + "_level_1_quarterly"
     ] = `calculator.${hesabuPackage.code}_${activity.code}_${substit}_level_1_quarterly_${orgunitid}_${period}()`;
+    substitutions[
+      substit + "_quarterly"
+    ] = `calculator.${hesabuPackage.code}_${activity.code}_${substit}_quarterly_${orgunitid}_${period}()`;
+
   }
   if (hesabuPackage.activity_decision_tables) {
     for (let rawDecisionTable of hesabuPackage.activity_decision_tables) {
@@ -298,6 +329,7 @@ export const generateCode = (
       // states getter/setter
       for (let state of states) {
         codes.push(generateGetterSetterForState(hesabuPackage, activity, state, orgunitid, period));
+        codes.push(generateGetterSetterForStateQuarterly(hesabuPackage, activity, state, orgunitid, period));
         codes.push(generateGetterSetterForStateLevel1Quarterly(hesabuPackage, activity, state, orgUnit, period));
       }
 

--- a/src/components/dataentry/CompleteDataSetButton.js
+++ b/src/components/dataentry/CompleteDataSetButton.js
@@ -1,41 +1,60 @@
 import React, { useEffect, useState, useContext } from "react";
 import { Button } from "@material-ui/core";
 import FormDataContext from "./FormDataContext";
+import { dsRegistrationPeriods } from "./forms";
 
-const CompleteDataSetButton = ({ variant, calculations, completable, dataSetId }) => {
+const CompleteDataSetButton = ({ variant, calculations, completable, dataSetId, period, children }) => {
   const isDataSetCompletable = completable == undefined ? true : completable;
   const formDataContext = useContext(FormDataContext);
 
+  let currentDataSetIds = [];
+  if (dataSetId) {
+    currentDataSetIds.push(dataSetId);
+  } else if (formDataContext.dataSets) {
+    currentDataSetIds = formDataContext.dataSets.map((c) => c.id);
+  } else if (formDataContext.dataSet) {
+    currentDataSetIds = [formDataContext.dataSet.id];
+  }
+
   useEffect(() => {
-    setComplete(formDataContext.isDataSetComplete(currentDataSetId));
+    setComplete(formDataContext.areDataSetsComplete(currentDataSetIds, period || formDataContext.period));
     console.log("formData modified !");
   }, [formDataContext.completeDataSetRegistrations]);
   const [loading, setLoading] = useState(false);
-  const currentDataSetId = dataSetId ? dataSetId : formDataContext.dataSet.id;
-  const [isComplete, setComplete] = useState(formDataContext.isDataSetComplete(currentDataSetId));
-  const isWritable = formDataContext.isDataWritable(currentDataSetId);
+  const [isComplete, setComplete] = useState(formDataContext.areDataSetsComplete(currentDataSetIds));
+  const isWritable = formDataContext.areDataWritable(currentDataSetIds);
   const onClick = async () => {
     setLoading(true);
+    const desiredState = !isComplete;
     try {
-      await formDataContext.toggleComplete(calculations, currentDataSetId);
+      let dataSets = formDataContext.dataSets.filter(ds => currentDataSetIds.includes(ds.id) )
+      for (let dataSet of dataSets) {
+        const regPeriods = dsRegistrationPeriods(dataSet, period || formDataContext.period);
+        for (const regPeriod of regPeriods) {
+          const currentState = formDataContext.isDataSetComplete(dataSet.id, regPeriod);
+          if (desiredState !== currentState) {
+            await formDataContext.toggleComplete(calculations, dataSet.id, regPeriod);           
+          }
+        }
+      }
     } finally {
       setLoading(false);
     }
   };
   return (
     <Button
-      key={currentDataSetId + "-" + isComplete}
+      key={currentDataSetIds.join("-") + "-" + isComplete}
       variant={variant || "contained"}
       disabled={loading || !isWritable || (!isComplete && !isDataSetCompletable)}
       color="primary"
       onClick={onClick}
       title={JSON.stringify(
-        formDataContext.completeDataSetRegistrations.filter((r) => r.dataSet == currentDataSetId),
+        formDataContext.completeDataSetRegistrations.filter((r) => currentDataSetIds.includes(r.dataSet)),
         undefined,
         2,
       )}
     >
-      {isComplete ? "Uncomplete" : "Complete"}
+      {isComplete ? "Uncomplete" : "Complete"} {children}
     </Button>
   );
 };

--- a/src/components/dataentry/Dhis2Input.js
+++ b/src/components/dataentry/Dhis2Input.js
@@ -47,8 +47,8 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth, period, dataSet, onFoc
   if (formDataContext == undefined) {
     return <></>;
   }
-  const isComplete = formDataContext.isDataSetComplete(dataSet);
-  const isDataWritable = formDataContext.isDataWritable(dataSet);
+  const isComplete = formDataContext.isDataSetComplete(dataSet, period);
+  const isDataWritable = formDataContext.isDataWritable(dataSet, period);
 
   const onChange = (e) => {
     setRawValue(e.target.value);

--- a/src/components/dataentry/Dhis2Input.js
+++ b/src/components/dataentry/Dhis2Input.js
@@ -12,7 +12,7 @@ import {
 import FormDataContext from "./FormDataContext";
 import useDebounce from "../shared/useDebounce";
 
-const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
+const Dhis2Input = ({ element, dataElement, t, fullWidth, period, dataSet, onFocus, onBlur }) => {
   const formDataContext = useContext(FormDataContext);
   const [rawValue, setRawValue] = useState("");
   const [dataValue, setDataValue] = useState("");
@@ -26,7 +26,7 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
   const isBoolean = dataElementDescriptor && dataElementDescriptor.valueType == "BOOLEAN";
 
   useEffect(() => {
-    const value = formDataContext && formDataContext.getValue && formDataContext.getValue(dataElement);
+    const value = formDataContext && formDataContext.getValue && formDataContext.getValue(dataElement, period);
     const dataValue = value !== undefined ? value : { dataElement: dataElement, value: "" };
     setDataValue(dataValue);
     const defaultRawValue = dataValue !== undefined ? dataValue.value : "";
@@ -35,15 +35,20 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
 
   useEffect(() => {
     if (formDataContext && debouncedState !== undefined && formDataContext.updateValue) {
-      formDataContext.updateValue(dataElement, debouncedState);
+      formDataContext.updateValue({
+        dataElement: dataElement,
+        value: debouncedState,
+        givenPeriod: period,
+        givenDataSetId: dataSet,
+      });
     }
   }, [debouncedState]);
 
   if (formDataContext == undefined) {
     return <></>;
   }
-  const isComplete = formDataContext.isDataSetComplete();
-  const isDataWritable = formDataContext.isDataWritable();
+  const isComplete = formDataContext.isDataSetComplete(dataSet);
+  const isDataWritable = formDataContext.isDataWritable(dataSet);
 
   const onChange = (e) => {
     setRawValue(e.target.value);
@@ -53,7 +58,7 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
   const onBooleanChange = (e) => {
     setRawValue(e.target.value);
     setDebouncedState(e.target.value);
-  }
+  };
 
   const handleOpenToolTip = () => {
     setOpen(true);
@@ -62,14 +67,13 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
     setOpen(false);
   };
 
-
   const widget = isBoolean ? (
     <FormControl
       style={{
         backgroundColor:
-          formDataContext && formDataContext.isModified(dataElement)
+          formDataContext && formDataContext.isModified(dataElement, period)
             ? "#badbad"
-            : formDataContext.isUpdating(dataElement)
+            : formDataContext.isUpdating(dataElement, period)
             ? "orange"
             : "",
       }}
@@ -82,26 +86,28 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
     </FormControl>
   ) : (
     <TextField
-      error={formDataContext.isInvalid(dataElement)}
+      error={formDataContext.isInvalid(dataElement, period)}
       type="text"
       disabled={isComplete || !isDataWritable}
       value={rawValue}
       onChange={onChange}
       onDoubleClick={handleOpenToolTip}
       onClick={handleCloseToolTip}
+      onFocus={onFocus}
+      onBlur={onBlur}
       fullWidth={fullWidth}
       inputProps={{
         style: {
           textAlign: "right",
           backgroundColor:
-            formDataContext && formDataContext.isModified(dataElement)
+            formDataContext && formDataContext.isModified(dataElement, period)
               ? "#badbad"
-              : formDataContext.isUpdating(dataElement)
+              : formDataContext.isUpdating(dataElement, period)
               ? "orange"
               : "",
         },
       }}
-      helperText={formDataContext && formDataContext.error(dataElement)}
+      helperText={formDataContext && formDataContext.error(dataElement, period)}
     />
   );
 
@@ -120,7 +126,7 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
           onClose={handleCloseToolTip}
           title={
             <div>
-              <pre>{JSON.stringify({ dataValue, isComplete, isDataWritable }, undefined, 2)}</pre>
+              <pre>{JSON.stringify({ period, dataValue, isComplete, isDataWritable }, undefined, 2)}</pre>
             </div>
           }
         >

--- a/src/components/dataentry/forms.js
+++ b/src/components/dataentry/forms.js
@@ -166,8 +166,8 @@ export const buildFormData = async ({ dhis2, api, dataEntryCode, activeContract,
       const dataSet = dataSetId ? this.dataSets.find((d) => d.id == dataSetId) : this.dataSet;
       return dataSet && dataSet.access && dataSet.access.data.write;
     },
-    error(de) {
-      return this.errors[this.getKey(de)];
+    error(de, givenPeriod) {
+      return this.errors[this.getKey(de, givenPeriod)];
     },
     getKey(de, givenPeriod) {
       const deCoc = de.split(".");
@@ -201,7 +201,12 @@ export const buildFormData = async ({ dhis2, api, dataEntryCode, activeContract,
         ? `${hesabuPackage.code}_${activity.code}_${formulaCode}_${orgUnitId}_${period}`
         : `${hesabuPackage.code}_${formulaCode}_${orgUnitId}_${period}`;
       if (this.calculator && this.calculator[calculatorFunction]) {
+        try {
         return this.calculator[calculatorFunction]();
+        } catch (e) {
+          console.log(e)
+          throw e
+        }
       }
     },
     async updateValue({ dataElement, value, givenPeriod, givenDataSetId}) {

--- a/src/components/dataentry/forms.js
+++ b/src/components/dataentry/forms.js
@@ -169,28 +169,29 @@ export const buildFormData = async ({ dhis2, api, dataEntryCode, activeContract,
     error(de) {
       return this.errors[this.getKey(de)];
     },
-    getKey(de) {
+    getKey(de, givenPeriod) {
       const deCoc = de.split(".");
-      return [activeContract.orgUnit.id, period, deCoc[0], deCoc[1] || defaultCoc].join("-");
+      return [activeContract.orgUnit.id, givenPeriod || period, deCoc[0], deCoc[1] || defaultCoc].join("-");
     },
-    getError(de) {
-      const key = this.getKey(de);
+    getError(de, givenPeriod) {
+      const key = this.getKey(de, givenPeriod);
       return this.errors[key];
     },
-    isModified(de) {
-      const key = this.getKey(de);
+    isModified(de, givenPeriod) {
+      const key = this.getKey(de, givenPeriod);
       return this.valids[key] == true;
     },
-    isUpdating(de) {
-      const key = this.getKey(de);
+    isUpdating(de, givenPeriod) {
+      const key = this.getKey(de, givenPeriod);
       return this.updating[key] == true;
     },
-    isInvalid(de) {
-      const key = this.getKey(de);
+    isInvalid(de, givenPeriod) {
+      const key = this.getKey(de, givenPeriod);
       return this.valids[key] == false;
     },
-    getValue(de) {
-      const key = this.getKey(de);
+    getValue(de, givenPeriod) {
+      const key = this.getKey(de, givenPeriod);
+      debugger;
       const ourValues = this.indexedValues[key];
       return ourValues ? ourValues[0] : undefined;
     },
@@ -203,9 +204,10 @@ export const buildFormData = async ({ dhis2, api, dataEntryCode, activeContract,
         return this.calculator[calculatorFunction]();
       }
     },
-    async updateValue(de, value) {
+    async updateValue({ dataElement, value, givenPeriod, givenDataSetId}) {
+      const de = dataElement
       const deCoc = de.split(".");
-      const key = this.getKey(de);
+      const key = this.getKey(de, givenPeriod);
       if (this.updating[key]) {
         return;
       } else {
@@ -214,9 +216,9 @@ export const buildFormData = async ({ dhis2, api, dataEntryCode, activeContract,
       const newValue = {
         de: deCoc[0],
         co: deCoc[1] || defaultCoc,
-        ds: dataSet.id,
+        ds: givenDataSetId || dataSet.id,
         ou: activeContract.orgUnit.id,
-        pe: period,
+        pe: givenPeriod || period,
         value: value,
       };
       try {

--- a/src/components/dataentry/forms.js
+++ b/src/components/dataentry/forms.js
@@ -191,7 +191,7 @@ export const buildFormData = async ({ dhis2, api, dataEntryCode, activeContract,
     },
     getValue(de, givenPeriod) {
       const key = this.getKey(de, givenPeriod);
-      debugger;
+      
       const ourValues = this.indexedValues[key];
       return ourValues ? ourValues[0] : undefined;
     },


### PR DESCRIPTION
this allows to create a data entry like this one mixing datasets and periods
```jsx
          <td>
              <Dhis2Input
                  dataElement={activity.cibles + DEFAULT_COMBO}
                  period={period}
                  dataSet="I370OL0cH35"
                  onFocus={() => {setFocusedActivity(activity)}}
                />
         </td>
             {monthlyPeriods.map((monthPeriod) => (
                <>
                  <td>
                    <Dhis2Input
                      dataElement={activity.declared + DEFAULT_COMBO}
                      period={monthPeriod}
                      onFocus={() => {setFocusedActivity(activity)}}
                    />
                  </td>
                  <td>
                    <Dhis2Input
                      dataElement={activity.verified + DEFAULT_COMBO}
                      period={monthPeriod}
                      onFocus={() => {setFocusedActivity(activity)}}
                    />
                  </td>
                </>
              ))}
```

the dhis2 dataset complete button should be ok (to specify a dateSetId and period, or will act on all)
```
              <CompleteDataSetButton
                    calculations={calculations}
                    dataSetId={"eHRG68viZwb"}
                    period={monthPeriod}
                  />
```
in this case the data isn't loaded by the "form context" but via the fetchExtraData

![demo-dataentry-multi-periods](https://user-images.githubusercontent.com/371692/167645722-2ce8f194-4a9c-4bb5-a411-e654d3adb985.gif)

