### PR TITLE
Disable radio button when the form is complete or not data writable

### DIFF
--- a/src/components/dataentry/Dhis2Input.js
+++ b/src/components/dataentry/Dhis2Input.js
@@ -44,6 +44,7 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
   }
   const isComplete = formDataContext.isDataSetComplete();
   const isDataWritable = formDataContext.isDataWritable();
+  const disabled = isComplete || !isDataWritable;
 
   const onChange = (e) => {
     setRawValue(e.target.value);
@@ -53,7 +54,7 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
   const onBooleanChange = (e) => {
     setRawValue(e.target.value);
     setDebouncedState(e.target.value);
-  }
+  };
 
   const handleOpenToolTip = () => {
     setOpen(true);
@@ -61,7 +62,6 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
   const handleCloseToolTip = () => {
     setOpen(false);
   };
-
 
   const widget = isBoolean ? (
     <FormControl
@@ -74,17 +74,32 @@ const Dhis2Input = ({ element, dataElement, t, fullWidth }) => {
             : "",
       }}
     >
-      <RadioGroup row value={rawValue} onChange={onBooleanChange} disabled={isComplete || !isDataWritable}>
-        <FormControlLabel value="true" control={<Radio />} label={t("dataEntry.valueType.BOOLEAN.true")} />
-        <FormControlLabel value="false" control={<Radio />} label={t("dataEntry.valueType.BOOLEAN.false")} />
-        <FormControlLabel value="" control={<Radio />} label={t("dataEntry.valueType.BOOLEAN.undefined")} />
+      <RadioGroup row value={rawValue} onChange={onBooleanChange} disabled={disabled}>
+        <FormControlLabel
+          value="true"
+          disabled={disabled}
+          control={<Radio />}
+          label={t("dataEntry.valueType.BOOLEAN.true")}
+        />
+        <FormControlLabel
+          value="false"
+          disabled={disabled}
+          control={<Radio />}
+          label={t("dataEntry.valueType.BOOLEAN.false")}
+        />
+        <FormControlLabel
+          value=""
+          disabled={disabled}
+          control={<Radio />}
+          label={t("dataEntry.valueType.BOOLEAN.undefined")}
+        />
       </RadioGroup>
     </FormControl>
   ) : (
     <TextField
       error={formDataContext.isInvalid(dataElement)}
       type="text"
-      disabled={isComplete || !isDataWritable}
+      disabled={disabled}
       value={rawValue}
       onChange={onChange}
       onDoubleClick={handleOpenToolTip}


### PR DESCRIPTION
The dhis2 input radio button seems not to be disabled when the form is complete or not writable in  invoice app. And in that case the value of dataelement linked to the field can be changed. 

Tested on Burundi where the customer asked us to allow him to chose to apply or not the community verification.


![RBF-Reporting-Community_verif](https://user-images.githubusercontent.com/6383219/168229082-7eb67295-8192-41e4-a601-db032b7e369d.png)

