### PR TITLE
Fix createTheme in contract import wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# @blsq/blsq-report-components@1.1.2
+
+- [contracts] fix contracts import wizard (error on createMuiTheme)
+
 # @blsq/blsq-report-components@1.1.1
 
 - [invoices] Adds a signalic section with map and photo if available

--- a/src/components/contracts/wizard/Step2.js
+++ b/src/components/contracts/wizard/Step2.js
@@ -17,6 +17,14 @@ function isIsoDate(str) {
   }
 }
 
+const getMuiTheme = () =>
+  createTheme({
+    overrides: {
+      MuiTableCell: { whiteSpace: "nowrap" },
+      MUIDataTableBodyCell: { root: { whiteSpace: "nowrap" } },
+    },
+  });
+
 const Step2 = ({ contractsToImport, dhis2, setValidatedContracts, setIsLoading }) => {
   const contractService = PluginRegistry.extension("contracts.service");
   const [contracts, setContracts] = useState(undefined);
@@ -178,14 +186,6 @@ const Step2 = ({ contractsToImport, dhis2, setValidatedContracts, setIsLoading }
     setRowsSelected(rowsSelected);
     setValidatedContracts(rowsSelected.map((index) => contracts[index]));
   };
-
-  const getMuiTheme = () =>
-    createMuiTheme({
-      overrides: {
-        MuiTableCell: { whiteSpace: "nowrap" },
-        MUIDataTableBodyCell: { root: { whiteSpace: "nowrap" } },
-      },
-    });
 
   return (
     <div style={{ maxWidth: "95%" }}>


### PR DESCRIPTION
```
react_devtools_backend.js:4026 ReferenceError: createMuiTheme is not defined
    at Step2 (index.es.js:10917:12)
    at Go (react-dom.production.min.js:153:146)
    at ms (react-dom.production.min.js:261:496)
    at lc (react-dom.production.min.js:246:265)
    at sc (react-dom.production.min.js:246:194)
    at Js (react-dom.production.min.js:239:172)
    at react-dom.production.min.js:123:115
    at t.unstable_runWithPriority (scheduler.production.min.js:19:467)
    at Fa (react-dom.production.min.js:122:325)
    at $a (react-dom.production.min.js:123:61)
```